### PR TITLE
[FEAT] 탈퇴 UI 구현

### DIFF
--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B5ACF6F32B22D2F2006D7641 /* QuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF6F22B22D2F2006D7641 /* QuestionView.swift */; };
 		B5ACF6F52B22DA42006D7641 /* RecordDiffableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF6F42B22DA42006D7641 /* RecordDiffableModel.swift */; };
 		B5ACF6F72B22DA61006D7641 /* RecordDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF6F62B22DA61006D7641 /* RecordDummy.swift */; };
+		B5ACF7022B24A4B3006D7641 /* ResignDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7012B24A4B3006D7641 /* ResignDescriptionView.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
 		C0121A2E2B1347CA00D10EB0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2D2B1347CA00D10EB0 /* SceneDelegate.swift */; };
 		C0121A352B1347CB00D10EB0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0121A342B1347CB00D10EB0 /* Assets.xcassets */; };
@@ -122,6 +123,7 @@
 		B5ACF6F22B22D2F2006D7641 /* QuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionView.swift; sourceTree = "<group>"; };
 		B5ACF6F42B22DA42006D7641 /* RecordDiffableModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordDiffableModel.swift; sourceTree = "<group>"; };
 		B5ACF6F62B22DA61006D7641 /* RecordDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordDummy.swift; sourceTree = "<group>"; };
+		B5ACF7012B24A4B3006D7641 /* ResignDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignDescriptionView.swift; sourceTree = "<group>"; };
 		C0121A282B1347CA00D10EB0 /* Plu-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Plu-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C0121A2D2B1347CA00D10EB0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -558,6 +560,7 @@
 			isa = PBXGroup;
 			children = (
 				C05E26892B1D9EAE00D91BFA /* ResignViewController.swift */,
+				B5ACF7012B24A4B3006D7641 /* ResignDescriptionView.swift */,
 			);
 			path = Resign;
 			sourceTree = "<group>";
@@ -853,6 +856,7 @@
 				C05E26742B1D9C6800D91BFA /* Combine+.swift in Sources */,
 				C05E26692B1D9B2F00D91BFA /* CALayer+.swift in Sources */,
 				C05E26652B1D9AEA00D91BFA /* Encodable+.swift in Sources */,
+				B5ACF7022B24A4B3006D7641 /* ResignDescriptionView.swift in Sources */,
 				B5ACF6CB2B1EE3EC006D7641 /* Dummy.swift in Sources */,
 				B5ACF6CF2B1EECD0006D7641 /* OthersAnswerTableView.swift in Sources */,
 				C05E269A2B1D9F1B00D91BFA /* SplashViewController.swift in Sources */,

--- a/Plu-iOS/Plu-iOS/Global/Constant/StringConstant.swift
+++ b/Plu-iOS/Plu-iOS/Global/Constant/StringConstant.swift
@@ -25,4 +25,11 @@ enum StringConstant {
             }
         }
     }
+    
+    enum Resign {
+        static let resignDescriptionText = "회원 탈퇴 시 기존에 등록한 게시글, 공감 등\n모든 활동 정보가 삭제되며 복구가 불가능합니다.\n정말 탈퇴하실 건가요?"
+        static let resignTitleText = "Plu님과 이별인가요?\n너무 아쉬워요."
+        static let reuseText = "다시 사용하기"
+        static let resignText = "탈퇴하기"
+    }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Resign/ResignDescriptionView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Resign/ResignDescriptionView.swift
@@ -1,0 +1,43 @@
+//
+//  ResignDescriptionView.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/9/23.
+//
+
+import UIKit
+
+final class ResignDescriptionView: UIView {
+    
+    private var descriptionLabel = PLULabel(type: .body3, color: .gray700, backgroundColor: .gray10, alignment: .center, lines: 3, text: StringConstant.Resign.resignDescriptionText)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setHierachy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        self.backgroundColor = .designSystem(.gray10)
+        self.layer.borderColor = .designSystem(.gray10)
+        self.layer.applyShadow()
+        self.layer.cornerRadius = 20
+    }
+    
+    private func setHierachy() {
+        self.addSubviews(descriptionLabel)
+    }
+    
+    private func setLayout() {
+        descriptionLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.edges.equalToSuperview().inset(20)
+        }
+    }
+
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Resign/ResignViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Resign/ResignViewController.swift
@@ -2,7 +2,7 @@
 //  ResignViewController.swift
 //  Plu-iOS
 //
-//  Created by uiskim on 2023/12/04.
+//  Created by 김민재 on 2023/12/04.
 //  Copyright (c) 2023 Resign. All rights reserved.
 //
 
@@ -12,45 +12,83 @@ import SnapKit
 
 final class ResignViewController: UIViewController {
     
+    private let airElementImageView = UIImageView(image: ImageLiterals.MyPage.farewellCharacter)
+    
+    private let resignTitleLabel = PLULabel(type: .head1, color: .gray700, backgroundColor: .background, alignment: .center, lines: 2, text: StringConstant.Resign.resignTitleText)
+    
+    private let descriptionView = ResignDescriptionView()
+    
+    private let reuseButton = PLUButton(config: .filled())
+        .setText(text: StringConstant.Resign.reuseText, font: .title1)
+        .setBackForegroundColor(backgroundColor: .gray600, foregroundColor: .white)
+        .setLayer(cornerRadius: 8, borderColor: .gray600)
+    
+    private let resignButton = PLUButton(config: .filled())
+        .setText(text: StringConstant.Resign.resignText, font: .title1)
+        .setBackForegroundColor(backgroundColor: .gray50, foregroundColor: .gray300)
+        .setLayer(cornerRadius: 8, borderColor: .gray50)
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        // MARK: - 컴포넌트 설정
         setUI()
-        
-        // MARK: - addsubView
         setHierarchy()
-        
-        // MARK: - autolayout설정
         setLayout()
-        
-        // MARK: - button의 addtarget설정
-        setAddTarget()
-        
-        // MARK: - delegate설정
-        setDelegate()
-
+        setUpdateHandler()
     }
 }
 
 private extension ResignViewController {
     func setUI() {
-        
+        self.view.backgroundColor = .designSystem(.background)
     }
     
     func setHierarchy() {
+        self.view.addSubviews(airElementImageView,
+                              resignTitleLabel,
+                              descriptionView,
+                              reuseButton,
+                              resignButton)
         
     }
     
     func setLayout() {
+        airElementImageView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(69)
+        }
+        
+        resignTitleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(airElementImageView.snp.bottom).offset(16)
+        }
+        
+        descriptionView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(resignTitleLabel.snp.bottom).offset(32)
+            make.leading.trailing.equalToSuperview().inset(36)
+        }
+        
+        reuseButton.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(44)
+        }
+        
+        resignButton.snp.makeConstraints { make in
+            make.top.equalTo(reuseButton.snp.bottom).offset(12)
+            make.leading.trailing.equalTo(reuseButton)
+            make.height.equalTo(44)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(24)
+        }
         
     }
     
-    func setAddTarget() {
+    func setUpdateHandler() {
+        reuseButton.setUpdateHandler { button in
+            print("reuse button tapped : \(button.isSelected)")
+        }
         
-    }
-    
-    func setDelegate() {
-        
+        resignButton.setUpdateHandler { button in
+            print("reuse button tapped : \(button.isSelected)")
+        }
     }
 }


### PR DESCRIPTION
## 🌱 작업한 내용
- 탈퇴 UI 구현

## 🌱 PR Point
탈퇴 UI 구현했습니다. 특별히 남길만한 포인트는 없었던 것 같습니다. 이 후 찬미 뷰가 머지되면, 공통되는 말풍선 뷰를 공용으로 사용하는 뷰로 바꿀  예정입니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 탈퇴화면 | <img src="https://github.com/Team-Plu/Plu-iOS/assets/60292150/7ba4c5e4-6c19-41dd-92c2-05f57f8e1a63" width="200"/> |



## 📮 관련 이슈

- Resolved: #19
