### PR TITLE
[ADD] (임시UI)AlarmPopUp 구현(#32)

### DIFF
--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -86,6 +86,10 @@
 		C0682A822B25857200AD4DB4 /* PLUTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A812B25857200AD4DB4 /* PLUTextField.swift */; };
 		C0682A852B25860D00AD4DB4 /* NicknameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A842B25860D00AD4DB4 /* NicknameManager.swift */; };
 		C0682A882B25862200AD4DB4 /* NicknameManagerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */; };
+		C083F6262B27EDBA00808AE6 /* PopUpDimmedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F6252B27EDBA00808AE6 /* PopUpDimmedViewController.swift */; };
+		C083F62A2B27EE4400808AE6 /* AlarmPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F6292B27EE4400808AE6 /* AlarmPopUpViewController.swift */; };
+		C083F62C2B27F20500808AE6 /* RegisterPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F62B2B27F20500808AE6 /* RegisterPopUpViewController.swift */; };
+		C083F6302B27F30200808AE6 /* SelectMonthPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F62F2B27F30200808AE6 /* SelectMonthPopUpViewController.swift */; };
 		C0A2561D2B1ED99B0059AA7E /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561C2B1ED99B0059AA7E /* MyPageHeaderView.swift */; };
 		C0A2561F2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561E2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift */; };
 		C0A256232B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A256222B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift */; };
@@ -208,6 +212,10 @@
 		C0682A812B25857200AD4DB4 /* PLUTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLUTextField.swift; sourceTree = "<group>"; };
 		C0682A842B25860D00AD4DB4 /* NicknameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameManager.swift; sourceTree = "<group>"; };
 		C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameManagerStub.swift; sourceTree = "<group>"; };
+		C083F6252B27EDBA00808AE6 /* PopUpDimmedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpDimmedViewController.swift; sourceTree = "<group>"; };
+		C083F6292B27EE4400808AE6 /* AlarmPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmPopUpViewController.swift; sourceTree = "<group>"; };
+		C083F62B2B27F20500808AE6 /* RegisterPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPopUpViewController.swift; sourceTree = "<group>"; };
+		C083F62F2B27F30200808AE6 /* SelectMonthPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectMonthPopUpViewController.swift; sourceTree = "<group>"; };
 		C0A2561C2B1ED99B0059AA7E /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
 		C0A2561E2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageRoundSectionHeaderView.swift; sourceTree = "<group>"; };
 		C0A256222B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAlarmTableViewCell.swift; sourceTree = "<group>"; };
@@ -383,6 +391,7 @@
 		C05E26472B1D976E00D91BFA /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
+				C083F6242B27ED9B00808AE6 /* PopUp */,
 				C0E0D4F52B26C7C500840C0B /* NicknameEdit */,
 				C05E26822B1D9E5B00D91BFA /* MyPage */,
 				C05E26812B1D9E5500D91BFA /* Resign */,
@@ -676,6 +685,17 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		C083F6242B27ED9B00808AE6 /* PopUp */ = {
+			isa = PBXGroup;
+			children = (
+				C083F6252B27EDBA00808AE6 /* PopUpDimmedViewController.swift */,
+				C083F6292B27EE4400808AE6 /* AlarmPopUpViewController.swift */,
+				C083F62B2B27F20500808AE6 /* RegisterPopUpViewController.swift */,
+				C083F62F2B27F30200808AE6 /* SelectMonthPopUpViewController.swift */,
+			);
+			path = PopUp;
+			sourceTree = "<group>";
+		};
 		C0CEF3DC2B267A3E00682D1B /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -922,6 +942,7 @@
 				C0A2561F2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift in Sources */,
 				4ABEEDBE2B27E7310020DA86 /* KeyboardType.swift in Sources */,
 				C05E263F2B1C4E1E00D91BFA /* UIFont+.swift in Sources */,
+				C083F6302B27F30200808AE6 /* SelectMonthPopUpViewController.swift in Sources */,
 				C05E26962B1D9F0600D91BFA /* OnboardingViewController.swift in Sources */,
 				C05E266D2B1D9B7200D91BFA /* UITextField+.swift in Sources */,
 				B5ACF7042B26C807006D7641 /* RecordDiffableDataSource.swift in Sources */,
@@ -943,6 +964,7 @@
 				C0E93B552B2046EE0098A822 /* MyPageTableView.swift in Sources */,
 				C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */,
 				4AA747652B25B8C8004D0335 /* PLUExplanationView.swift in Sources */,
+				C083F62C2B27F20500808AE6 /* RegisterPopUpViewController.swift in Sources */,
 				C05E26982B1D9F1000D91BFA /* LoginViewController.swift in Sources */,
 				B5ACF6DA2B208B8A006D7641 /* AnswerFilterButtonType.swift in Sources */,
 				C05E268E2B1D9EC800D91BFA /* OthersAnswerViewController.swift in Sources */,
@@ -955,11 +977,13 @@
 				C0E93B4E2B2036E50098A822 /* MyPageSection.swift in Sources */,
 				C0E0D4F72B26C7FC00840C0B /* NicknameEditViewController.swift in Sources */,
 				C05E265D2B1D9A5900D91BFA /* CollectionSectionViewRegisterDequeueProtocol.swift in Sources */,
+				C083F62A2B27EE4400808AE6 /* AlarmPopUpViewController.swift in Sources */,
 				B5ACF6F32B22D2F2006D7641 /* QuestionView.swift in Sources */,
 				C0A256232B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift in Sources */,
 				C05E268C2B1D9EB600D91BFA /* RecordViewController.swift in Sources */,
 				C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */,
 				C00113DC2B2546DB00B2C799 /* PluTempButton.swift in Sources */,
+				C083F6262B27EDBA00808AE6 /* PopUpDimmedViewController.swift in Sources */,
 				C05E26922B1D9EED00D91BFA /* MyAnswerViewController.swift in Sources */,
 				C05E26882B1D9EA300D91BFA /* MyPageViewController.swift in Sources */,
 				4AA747572B1D74A6004D0335 /* CGColor+.swift in Sources */,

--- a/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
+++ b/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         Font.registerFonts()
-        let navigationController = UINavigationController(rootViewController: SplashViewController())
+        let navigationController = UINavigationController(rootViewController: SelectMonthPopUpViewController())
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/Plu-iOS/Plu-iOS/Scenes/PopUp/AlarmPopUpViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PopUp/AlarmPopUpViewController.swift
@@ -1,0 +1,99 @@
+//
+//  AlarmPopUpViewController.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/12.
+//  Copyright (c) 2023 AlarmPopUp. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+
+final class AlarmPopUpViewController: PopUpDimmedViewController {
+    
+    private let popUpBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .designSystem(.white)
+        view.clipsToBounds = false
+        view.layer.cornerRadius = 10
+        return view
+    }()
+    
+    private let popUpTitle = PLULabel(type: .head2, color: .gray700, lines: 2, text: "매일 저녁 10시\n알림을 드려도 될까요?")
+    
+    private let popUpSubTitle = PLULabel(type: .body2M, color: .gray500, lines: 2, text: "오늘의 질문을 놓치지 않을 수 있어요\n필요없는 알림은 보내지 않을게요!")
+    
+    private lazy var agreeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("알림을 받을래요", for: .normal)
+        button.backgroundColor = .designSystem(.gray600)
+        button.setTitleColor(.designSystem(.white), for: .normal)
+        button.titleLabel?.font = .suite(.title1)
+        button.addTarget(self, action: #selector(agreeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var disAgreeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("괜찮아요", for: .normal)
+        button.setTitleColor(.designSystem(.gray500), for: .normal)
+        button.titleLabel?.font = .suite(.body2M)
+        button.addTarget(self, action: #selector(disAgreeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    override init() {
+        super.init()
+        setUp()
+    }
+    
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc func agreeButtonTapped() {
+        print("확인버튼 눌림")
+    }
+    
+    @objc func disAgreeButtonTapped() {
+        print("취소버튼 눌림")
+    }
+    
+}
+
+private extension AlarmPopUpViewController {
+    func setUp() {
+        view.addSubview(popUpBackgroundView)
+        popUpBackgroundView.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview().inset(200)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        popUpBackgroundView.addSubviews(popUpTitle, popUpSubTitle, agreeButton, disAgreeButton)
+        popUpTitle.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(40)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(80)
+        }
+        popUpSubTitle.snp.makeConstraints { make in
+            make.top.equalTo(popUpTitle.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(68)
+        }
+        
+        agreeButton.snp.makeConstraints { make in
+            make.top.equalTo(popUpSubTitle.snp.bottom).offset(120)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(28)
+            make.height.equalTo(44)
+        }
+        
+        disAgreeButton.snp.makeConstraints { make in
+            make.top.equalTo(agreeButton.snp.bottom).offset(12)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(28)
+            make.height.equalTo(44)
+        }
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/PopUp/PopUpDimmedViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PopUp/PopUpDimmedViewController.swift
@@ -1,0 +1,49 @@
+//
+//  PopUpDimmedViewController.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/12.
+//
+
+import UIKit
+
+class PopUpDimmedViewController: UIViewController {
+    private let dimmedView = UIView()
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        modalTransitionStyle = .coverVertical
+        modalPresentationStyle = .overFullScreen
+    }
+    
+    required public init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        guard let presentingViewController else { return }
+        dimmedView.backgroundColor = .designSystem(.black)
+        dimmedView.alpha = 0
+        presentingViewController.view.addSubview(dimmedView)
+        
+        dimmedView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        UIView.animate(withDuration: 0.3) {
+            self.dimmedView.alpha = 0.25
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        UIView.animate(withDuration: 0.3) {
+            self.dimmedView.alpha = 0
+        } completion: { _ in
+            self.dimmedView.removeFromSuperview()
+        }
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/PopUp/RegisterPopUpViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PopUp/RegisterPopUpViewController.swift
@@ -1,0 +1,98 @@
+//
+//  RegisterPopUpViewController.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/12.
+//
+
+import UIKit
+
+import SnapKit
+
+final class RegisterPopUpViewController: PopUpDimmedViewController {
+    
+    private let popUpBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .designSystem(.white)
+        view.clipsToBounds = false
+        view.layer.cornerRadius = 10
+        return view
+    }()
+    
+    private let popUpTitle = PLULabel(type: .head2, color: .gray700, text: "이대로 글을 등록할까요?")
+    
+    private let popUpSubTitle = PLULabel(type: .body2M, color: .gray500, lines: 2, text: "한번글을 등록하고 나면\n글의 내용과 공개여부 수정이 불가능해요.")
+    
+    private lazy var agreeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("등록하기", for: .normal)
+        button.backgroundColor = .designSystem(.gray600)
+        button.setTitleColor(.designSystem(.white), for: .normal)
+        button.titleLabel?.font = .suite(.title1)
+        button.addTarget(self, action: #selector(agreeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var disAgreeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("다시확인하기", for: .normal)
+        button.setTitleColor(.designSystem(.gray500), for: .normal)
+        button.titleLabel?.font = .suite(.body2M)
+        button.addTarget(self, action: #selector(disAgreeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    override init() {
+        super.init()
+        setUp()
+    }
+    
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc func agreeButtonTapped() {
+        print("확인버튼 눌림")
+    }
+    
+    @objc func disAgreeButtonTapped() {
+        print("취소버튼 눌림")
+    }
+    
+}
+
+private extension RegisterPopUpViewController {
+    func setUp() {
+        view.addSubview(popUpBackgroundView)
+        popUpBackgroundView.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview().inset(310)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        popUpBackgroundView.addSubviews(popUpTitle, popUpSubTitle, agreeButton, disAgreeButton)
+        popUpTitle.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(24)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(60)
+        }
+        popUpSubTitle.snp.makeConstraints { make in
+            make.top.equalTo(popUpTitle.snp.bottom).offset(8)
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(48)
+        }
+        
+        agreeButton.snp.makeConstraints { make in
+            make.top.equalTo(popUpSubTitle.snp.bottom).offset(20)
+            make.leading.equalToSuperview().inset(16)
+            make.height.equalTo(44)
+            make.width.equalTo(100)
+        }
+        
+        disAgreeButton.snp.makeConstraints { make in
+            make.top.equalTo(popUpSubTitle.snp.bottom).offset(20)
+            make.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(44)
+            make.width.equalTo(100)
+        }
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/PopUp/SelectMonthPopUpViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PopUp/SelectMonthPopUpViewController.swift
@@ -1,0 +1,84 @@
+//
+//  SelectMonthPopUpViewController.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/12.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SelectMonthPopUpViewController: PopUpDimmedViewController {
+    
+    private let popUpBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .designSystem(.white)
+        view.clipsToBounds = false
+        view.layer.cornerRadius = 10
+        return view
+    }()
+    
+    private lazy var monthPicker: UIDatePicker = {
+        let datePicker = UIDatePicker()
+        datePicker.datePickerMode = .date
+        datePicker.preferredDatePickerStyle = .wheels
+        datePicker.locale = Locale(identifier: "ko-KR")
+        datePicker.addTarget(self, action: #selector(dateChange(_:)), for: .valueChanged)
+        return datePicker
+    }()
+    
+    private lazy var agreeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("등록하기", for: .normal)
+        button.backgroundColor = .designSystem(.gray600)
+        button.setTitleColor(.designSystem(.white), for: .normal)
+        button.titleLabel?.font = .suite(.title1)
+        button.addTarget(self, action: #selector(agreeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    override init() {
+        super.init()
+        setUp()
+    }
+    
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc func agreeButtonTapped() {
+        print("확인버튼 눌림")
+    }
+    
+    @objc func dateChange(_ datePicker: UIDatePicker) {
+        let formmater = DateFormatter()
+        formmater.dateFormat = "yyyy 년 MM 월 dd 일(EEEEE)" //데이트 포멧형식 잡기
+        formmater.locale = Locale(identifier: "ko_KR") // 한국어 표현
+        print(formmater.string(from: datePicker.date))
+    }
+    
+}
+
+private extension SelectMonthPopUpViewController {
+    func setUp() {
+        view.addSubview(popUpBackgroundView)
+        popUpBackgroundView.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview().inset(310)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        popUpBackgroundView.addSubviews(monthPicker, agreeButton)
+        monthPicker.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalTo(250)
+            make.height.equalTo(100)
+        }
+        agreeButton.snp.makeConstraints { make in
+            make.top.equalTo(monthPicker.snp.bottom).offset(10)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(50)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+}


### PR DESCRIPTION
## [#32] ADD : (임시UI)AlarmPopUp 구현

## 🌱 작업한 내용
- Coordinator설계와 적용을 위해 PopUpCoordinator가 필요해서 임시로 PopUp을 구현했습니다
- 단순기능만 돌아가는 UI라 세부적인 디테일은 Coordinator적용이 끝나면 다시 진행하겠습니다

## 🌱 PR Point
- popup의 background를 결정하는 DimmedVC를 구현했습니다
- 알람여부, 글등록여부, 년/월선택 팝업을 구현했습니다
<img width="277" alt="스크린샷 2023-12-12 오전 11 49 19" src="https://github.com/Team-Plu/Plu-iOS/assets/99013115/aff385a2-3129-41de-a032-b8ce37598aac">


## 📮 관련 이슈

- Resolved: #32 
