### PR TITLE
[FEAT] Coordinator 설계 (#33)

### DIFF
--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		C0682A822B25857200AD4DB4 /* PLUTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A812B25857200AD4DB4 /* PLUTextField.swift */; };
 		C0682A852B25860D00AD4DB4 /* NicknameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A842B25860D00AD4DB4 /* NicknameManager.swift */; };
 		C0682A882B25862200AD4DB4 /* NicknameManagerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */; };
+		C07AB7272B2828A600C2E02C /* TabbarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */; };
 		C0A2561D2B1ED99B0059AA7E /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561C2B1ED99B0059AA7E /* MyPageHeaderView.swift */; };
 		C0A2561F2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561E2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift */; };
 		C0A256232B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A256222B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift */; };
@@ -242,6 +243,7 @@
 		C0682A812B25857200AD4DB4 /* PLUTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLUTextField.swift; sourceTree = "<group>"; };
 		C0682A842B25860D00AD4DB4 /* NicknameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameManager.swift; sourceTree = "<group>"; };
 		C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameManagerStub.swift; sourceTree = "<group>"; };
+		C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarCoordinator.swift; sourceTree = "<group>"; };
 		C0A2561C2B1ED99B0059AA7E /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
 		C0A2561E2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageRoundSectionHeaderView.swift; sourceTree = "<group>"; };
 		C0A256222B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAlarmTableViewCell.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */,
 				B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */,
 				B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */,
+				C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -1085,6 +1088,7 @@
 				B5ACF6CF2B1EECD0006D7641 /* OthersAnswerTableView.swift in Sources */,
 				C0682A822B25857200AD4DB4 /* PLUTextField.swift in Sources */,
 				C05E269A2B1D9F1B00D91BFA /* SplashViewController.swift in Sources */,
+				C07AB7272B2828A600C2E02C /* TabbarCoordinator.swift in Sources */,
 				B5ACF6F72B22DA61006D7641 /* RecordDummy.swift in Sources */,
 				C02C5DFE2B22E0780011F07C /* UIEdgeInsets+.swift in Sources */,
 				4A44666A2B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift in Sources */,

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -39,6 +39,16 @@
 		B5ACF7062B26D47C006D7641 /* TutorialCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7052B26D47C006D7641 /* TutorialCollectionViewCell.swift */; };
 		B5ACF70A2B26DEB1006D7641 /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7092B26DEB1006D7641 /* LoginModel.swift */; };
 		B5ACF70C2B26EC48006D7641 /* se+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF70B2B26EC48006D7641 /* se+.swift */; };
+		B5ACF7102B27F193006D7641 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF70F2B27F193006D7641 /* Coordinator.swift */; };
+		B5ACF7122B2812E2006D7641 /* SplashCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7112B2812E2006D7641 /* SplashCoordinator.swift */; };
+		B5ACF7142B28133E006D7641 /* AuthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7132B28133E006D7641 /* AuthCoordinator.swift */; };
+		B5ACF7162B2814CE006D7641 /* TodayQuestionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7152B2814CE006D7641 /* TodayQuestionCoordinator.swift */; };
+		B5ACF7182B281530006D7641 /* MyAnswerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7172B281530006D7641 /* MyAnswerCoordinator.swift */; };
+		B5ACF71A2B28158E006D7641 /* OtherAnswersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7192B28158E006D7641 /* OtherAnswersCoordinator.swift */; };
+		B5ACF71C2B2815CB006D7641 /* AnswerDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF71B2B2815CB006D7641 /* AnswerDetailCoordinator.swift */; };
+		B5ACF71E2B2815EA006D7641 /* RecordCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */; };
+		B5ACF7202B281622006D7641 /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */; };
+		B5ACF7222B2816C6006D7641 /* PopUpCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */; };
 		C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113D92B25359100B2C799 /* OnboardingViewModel.swift */; };
 		C00113DC2B2546DB00B2C799 /* PluTempButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113DB2B2546DB00B2C799 /* PluTempButton.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
@@ -160,6 +170,16 @@
 		B5ACF7052B26D47C006D7641 /* TutorialCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialCollectionViewCell.swift; sourceTree = "<group>"; };
 		B5ACF7092B26DEB1006D7641 /* LoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModel.swift; sourceTree = "<group>"; };
 		B5ACF70B2B26EC48006D7641 /* se+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "se+.swift"; sourceTree = "<group>"; };
+		B5ACF70F2B27F193006D7641 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		B5ACF7112B2812E2006D7641 /* SplashCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7132B28133E006D7641 /* AuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7152B2814CE006D7641 /* TodayQuestionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7172B281530006D7641 /* MyAnswerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAnswerCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7192B28158E006D7641 /* OtherAnswersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherAnswersCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF71B2B2815CB006D7641 /* AnswerDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerDetailCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpCoordinator.swift; sourceTree = "<group>"; };
 		C00113D92B25359100B2C799 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C00113DB2B2546DB00B2C799 /* PluTempButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluTempButton.swift; sourceTree = "<group>"; };
 		C0121A282B1347CA00D10EB0 /* Plu-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Plu-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -328,6 +348,31 @@
 			path = Enum;
 			sourceTree = "<group>";
 		};
+		B5ACF70D2B27F180006D7641 /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				B5ACF70E2B27F18B006D7641 /* Interface */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
+		B5ACF70E2B27F18B006D7641 /* Interface */ = {
+			isa = PBXGroup;
+			children = (
+				B5ACF70F2B27F193006D7641 /* Coordinator.swift */,
+				B5ACF7112B2812E2006D7641 /* SplashCoordinator.swift */,
+				B5ACF7132B28133E006D7641 /* AuthCoordinator.swift */,
+				B5ACF7152B2814CE006D7641 /* TodayQuestionCoordinator.swift */,
+				B5ACF7172B281530006D7641 /* MyAnswerCoordinator.swift */,
+				B5ACF7192B28158E006D7641 /* OtherAnswersCoordinator.swift */,
+				B5ACF71B2B2815CB006D7641 /* AnswerDetailCoordinator.swift */,
+				B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */,
+				B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */,
+				B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */,
+			);
+			path = Interface;
+			sourceTree = "<group>";
+		};
 		C0121A1F2B1347CA00D10EB0 = {
 			isa = PBXGroup;
 			children = (
@@ -393,6 +438,7 @@
 		C05E26472B1D976E00D91BFA /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
+				B5ACF70D2B27F180006D7641 /* Coordinator */,
 				4AA7476C2B261181004D0335 /* AnswerDetail */,
 				C0E0D4F52B26C7C500840C0B /* NicknameEdit */,
 				C05E26822B1D9E5B00D91BFA /* MyPage */,
@@ -916,6 +962,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0E0D4FB2B26CC4C00840C0B /* PLUImageView.swift in Sources */,
+				B5ACF71C2B2815CB006D7641 /* AnswerDetailCoordinator.swift in Sources */,
 				C05E262F2B1C48F200D91BFA /* Font.swift in Sources */,
 				C0E0D4F92B26C81700840C0B /* NicknameEditViewModel.swift in Sources */,
 				B5ACF6D62B2078B2006D7641 /* AnswerFilterMenuView.swift in Sources */,
@@ -923,6 +970,7 @@
 				B59FC6E72B1C44C9000996CA /* ImageLiterals.swift in Sources */,
 				C05E26592B1D9A1D00D91BFA /* TableViewCellRegisterDequeueProtocol.swift in Sources */,
 				C05E26722B1D9BCF00D91BFA /* UILabel+.swift in Sources */,
+				B5ACF7222B2816C6006D7641 /* PopUpCoordinator.swift in Sources */,
 				B5ACF6C92B1EE26C006D7641 /* ElementColor.swift in Sources */,
 				C0E93B5A2B20518B0098A822 /* TableSectionViewRegisterDequeueProtocol.swift in Sources */,
 				C05E26782B1D9D2900D91BFA /* StringConstant.swift in Sources */,
@@ -930,6 +978,7 @@
 				4AA747702B261221004D0335 /* PLUEverydayAnswerView.swift in Sources */,
 				4AA747612B24B495004D0335 /* AnswerCautionView.swift in Sources */,
 				C0E93B522B2046030098A822 /* MyPageSectionHeaderHeight.swift in Sources */,
+				B5ACF7142B28133E006D7641 /* AuthCoordinator.swift in Sources */,
 				C0E93B452B2035650098A822 /* MyPageAlarmCellData.swift in Sources */,
 				C0A2561F2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift in Sources */,
 				4ABEEDBE2B27E7310020DA86 /* KeyboardType.swift in Sources */,
@@ -939,7 +988,6 @@
 				B5ACF7042B26C807006D7641 /* RecordDiffableDataSource.swift in Sources */,
 				C0E93B4B2B20359B0098A822 /* MypageUserExitCellData.swift in Sources */,
 				C05E26902B1D9ED300D91BFA /* TabbarViewController.swift in Sources */,
-				4AA747592B22D0D8004D0335 /* EverydayAnswerView.swift in Sources */,
 				C0CEF3DE2B267A4B00682D1B /* NicknameState.swift in Sources */,
 				C0682A882B25862200AD4DB4 /* NicknameManagerStub.swift in Sources */,
 				C0E93B502B2037C20098A822 /* MyPageCellHeight.swift in Sources */,
@@ -950,6 +998,7 @@
 				C05E26702B1D9B8C00D91BFA /* UIStackView+.swift in Sources */,
 				4AA7475D2B22E28F004D0335 /* PLUUnderLine.swift in Sources */,
 				C05E26942B1D9EF700D91BFA /* TodayQuestionViewController.swift in Sources */,
+				B5ACF7182B281530006D7641 /* MyAnswerCoordinator.swift in Sources */,
 				B5ACF6C52B1EDFF3006D7641 /* PLULabel.swift in Sources */,
 				4AA7475B2B22DA38004D0335 /* PLUTextView.swift in Sources */,
 				4AA747532B1CEF9C004D0335 /* UIColor+.swift in Sources */,
@@ -963,8 +1012,11 @@
 				B5ACF6CD2B1EE735006D7641 /* AnswerView.swift in Sources */,
 				B5ACF6D12B1EEECB006D7641 /* OtherAnswersDiffableModel.swift in Sources */,
 				C0E93B472B20357B0098A822 /* MypageInfomationCellData.swift in Sources */,
+				B5ACF7102B27F193006D7641 /* Coordinator.swift in Sources */,
 				C0E93B432B2035580098A822 /* MyPageUserData.swift in Sources */,
+				B5ACF7122B2812E2006D7641 /* SplashCoordinator.swift in Sources */,
 				C0E93B402B2035370098A822 /* MyPageCell.swift in Sources */,
+				B5ACF71A2B28158E006D7641 /* OtherAnswersCoordinator.swift in Sources */,
 				C0E93B4E2B2036E50098A822 /* MyPageSection.swift in Sources */,
 				C0E0D4F72B26C7FC00840C0B /* NicknameEditViewController.swift in Sources */,
 				C05E265D2B1D9A5900D91BFA /* CollectionSectionViewRegisterDequeueProtocol.swift in Sources */,
@@ -975,6 +1027,7 @@
 				C00113DC2B2546DB00B2C799 /* PluTempButton.swift in Sources */,
 				C05E26922B1D9EED00D91BFA /* MyAnswerViewController.swift in Sources */,
 				C05E26882B1D9EA300D91BFA /* MyPageViewController.swift in Sources */,
+				B5ACF7162B2814CE006D7641 /* TodayQuestionCoordinator.swift in Sources */,
 				4AA747572B1D74A6004D0335 /* CGColor+.swift in Sources */,
 				C0E93B492B20358A0098A822 /* MypageAppVersionCellData.swift in Sources */,
 				C05E266B2B1D9B4C00D91BFA /* UIViewController+.swift in Sources */,
@@ -990,11 +1043,13 @@
 				B5ACF6D82B2086A9006D7641 /* PLUButton.swift in Sources */,
 				C05E268A2B1D9EAE00D91BFA /* ResignViewController.swift in Sources */,
 				B5ACF7062B26D47C006D7641 /* TutorialCollectionViewCell.swift in Sources */,
+				B5ACF71E2B2815EA006D7641 /* RecordCoordinator.swift in Sources */,
 				B5ACF6C72B1EE1B9006D7641 /* AnswerTableViewCell.swift in Sources */,
 				C05E26742B1D9C6800D91BFA /* Combine+.swift in Sources */,
 				C05E26692B1D9B2F00D91BFA /* CALayer+.swift in Sources */,
 				C05E26652B1D9AEA00D91BFA /* Encodable+.swift in Sources */,
 				B5ACF7022B24A4B3006D7641 /* ResignDescriptionView.swift in Sources */,
+				B5ACF7202B281622006D7641 /* MyPageCoordinator.swift in Sources */,
 				B5ACF6CB2B1EE3EC006D7641 /* Dummy.swift in Sources */,
 				B5ACF6CF2B1EECD0006D7641 /* OthersAnswerTableView.swift in Sources */,
 				C0682A822B25857200AD4DB4 /* PLUTextField.swift in Sources */,

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A44666A2B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4466692B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift */; };
+		4A44666C2B28208D002D5BF7 /* RecordCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A44666B2B28208D002D5BF7 /* RecordCoordinatorImpl.swift */; };
 		4AA747532B1CEF9C004D0335 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA747522B1CEF9C004D0335 /* UIColor+.swift */; };
 		4AA747552B1CF094004D0335 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA747542B1CF094004D0335 /* Palette.swift */; };
 		4AA747572B1D74A6004D0335 /* CGColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA747562B1D74A6004D0335 /* CGColor+.swift */; };
@@ -49,7 +51,7 @@
 		B5ACF71E2B2815EA006D7641 /* RecordCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */; };
 		B5ACF7202B281622006D7641 /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */; };
 		B5ACF7222B2816C6006D7641 /* PopUpCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */; };
-		B5ACF7252B2818D5006D7641 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7242B2818D5006D7641 /* AppCoordinator.swift */; };
+		B5ACF7252B2818D5006D7641 /* AppCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7242B2818D5006D7641 /* AppCoordinatorImpl.swift */; };
 		B5ACF7272B281928006D7641 /* SplashCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */; };
 		B5ACF7292B28196C006D7641 /* TabBarCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */; };
 		B5ACF72B2B281A19006D7641 /* AuthCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */; };
@@ -142,6 +144,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4A4466692B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionCoordinatorImpl.swift; sourceTree = "<group>"; };
+		4A44666B2B28208D002D5BF7 /* RecordCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinatorImpl.swift; sourceTree = "<group>"; };
 		4AA747522B1CEF9C004D0335 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		4AA747542B1CF094004D0335 /* Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		4AA747562B1D74A6004D0335 /* CGColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGColor+.swift"; sourceTree = "<group>"; };
@@ -184,7 +188,7 @@
 		B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinator.swift; sourceTree = "<group>"; };
 		B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpCoordinator.swift; sourceTree = "<group>"; };
-		B5ACF7242B2818D5006D7641 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7242B2818D5006D7641 /* AppCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorImpl.swift; sourceTree = "<group>"; };
 		B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashCoordinatorImpl.swift; sourceTree = "<group>"; };
 		B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinatorImpl.swift; sourceTree = "<group>"; };
 		B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinatorImpl.swift; sourceTree = "<group>"; };
@@ -385,10 +389,12 @@
 		B5ACF7232B2818C3006D7641 /* CoordinatorImpl */ = {
 			isa = PBXGroup;
 			children = (
-				B5ACF7242B2818D5006D7641 /* AppCoordinator.swift */,
+				B5ACF7242B2818D5006D7641 /* AppCoordinatorImpl.swift */,
 				B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */,
 				B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */,
 				B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */,
+				4A4466692B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift */,
+				4A44666B2B28208D002D5BF7 /* RecordCoordinatorImpl.swift */,
 			);
 			path = CoordinatorImpl;
 			sourceTree = "<group>";
@@ -1040,7 +1046,7 @@
 				B5ACF7122B2812E2006D7641 /* SplashCoordinator.swift in Sources */,
 				C0E93B402B2035370098A822 /* MyPageCell.swift in Sources */,
 				B5ACF71A2B28158E006D7641 /* OtherAnswersCoordinator.swift in Sources */,
-				B5ACF7252B2818D5006D7641 /* AppCoordinator.swift in Sources */,
+				B5ACF7252B2818D5006D7641 /* AppCoordinatorImpl.swift in Sources */,
 				C0E93B4E2B2036E50098A822 /* MyPageSection.swift in Sources */,
 				C0E0D4F72B26C7FC00840C0B /* NicknameEditViewController.swift in Sources */,
 				C05E265D2B1D9A5900D91BFA /* CollectionSectionViewRegisterDequeueProtocol.swift in Sources */,
@@ -1066,6 +1072,7 @@
 				C0682A852B25860D00AD4DB4 /* NicknameManager.swift in Sources */,
 				B5ACF6D82B2086A9006D7641 /* PLUButton.swift in Sources */,
 				C05E268A2B1D9EAE00D91BFA /* ResignViewController.swift in Sources */,
+				4A44666C2B28208D002D5BF7 /* RecordCoordinatorImpl.swift in Sources */,
 				B5ACF7062B26D47C006D7641 /* TutorialCollectionViewCell.swift in Sources */,
 				B5ACF71E2B2815EA006D7641 /* RecordCoordinator.swift in Sources */,
 				B5ACF6C72B1EE1B9006D7641 /* AnswerTableViewCell.swift in Sources */,
@@ -1080,6 +1087,7 @@
 				C05E269A2B1D9F1B00D91BFA /* SplashViewController.swift in Sources */,
 				B5ACF6F72B22DA61006D7641 /* RecordDummy.swift in Sources */,
 				C02C5DFE2B22E0780011F07C /* UIEdgeInsets+.swift in Sources */,
+				4A44666A2B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift in Sources */,
 				B5ACF70C2B26EC48006D7641 /* se+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -103,12 +103,13 @@
 		C0682A822B25857200AD4DB4 /* PLUTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A812B25857200AD4DB4 /* PLUTextField.swift */; };
 		C0682A852B25860D00AD4DB4 /* NicknameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A842B25860D00AD4DB4 /* NicknameManager.swift */; };
 		C0682A882B25862200AD4DB4 /* NicknameManagerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */; };
+		C07AB7272B2828A600C2E02C /* TabbarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */; };
+		C07AB7292B282E2D00C2E02C /* PopUpCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */; };
+		C07AB72B2B28380200C2E02C /* MyAnswerCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB72A2B28380200C2E02C /* MyAnswerCoordinatorImpl.swift */; };
 		C083F6262B27EDBA00808AE6 /* PopUpDimmedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F6252B27EDBA00808AE6 /* PopUpDimmedViewController.swift */; };
 		C083F62A2B27EE4400808AE6 /* AlarmPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F6292B27EE4400808AE6 /* AlarmPopUpViewController.swift */; };
 		C083F62C2B27F20500808AE6 /* RegisterPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F62B2B27F20500808AE6 /* RegisterPopUpViewController.swift */; };
 		C083F6302B27F30200808AE6 /* SelectMonthPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C083F62F2B27F30200808AE6 /* SelectMonthPopUpViewController.swift */; };
-		C07AB7272B2828A600C2E02C /* TabbarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */; };
-		C07AB7292B282E2D00C2E02C /* PopUpCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */; };
 		C0A2561D2B1ED99B0059AA7E /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561C2B1ED99B0059AA7E /* MyPageHeaderView.swift */; };
 		C0A2561F2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561E2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift */; };
 		C0A256232B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A256222B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift */; };
@@ -250,6 +251,7 @@
 		C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameManagerStub.swift; sourceTree = "<group>"; };
 		C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarCoordinator.swift; sourceTree = "<group>"; };
 		C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpCoordinatorImpl.swift; sourceTree = "<group>"; };
+		C07AB72A2B28380200C2E02C /* MyAnswerCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAnswerCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C083F6252B27EDBA00808AE6 /* PopUpDimmedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpDimmedViewController.swift; sourceTree = "<group>"; };
 		C083F6292B27EE4400808AE6 /* AlarmPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmPopUpViewController.swift; sourceTree = "<group>"; };
 		C083F62B2B27F20500808AE6 /* RegisterPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPopUpViewController.swift; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 				4A4466692B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift */,
 				4A44666B2B28208D002D5BF7 /* RecordCoordinatorImpl.swift */,
 				C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */,
+				C07AB72A2B28380200C2E02C /* MyAnswerCoordinatorImpl.swift */,
 			);
 			path = CoordinatorImpl;
 			sourceTree = "<group>";
@@ -1102,6 +1105,7 @@
 				C0682A852B25860D00AD4DB4 /* NicknameManager.swift in Sources */,
 				B5ACF6D82B2086A9006D7641 /* PLUButton.swift in Sources */,
 				C05E268A2B1D9EAE00D91BFA /* ResignViewController.swift in Sources */,
+				C07AB72B2B28380200C2E02C /* MyAnswerCoordinatorImpl.swift in Sources */,
 				4A44666C2B28208D002D5BF7 /* RecordCoordinatorImpl.swift in Sources */,
 				B5ACF7062B26D47C006D7641 /* TutorialCollectionViewCell.swift in Sources */,
 				B5ACF71E2B2815EA006D7641 /* RecordCoordinator.swift in Sources */,

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		B5ACF7272B281928006D7641 /* SplashCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */; };
 		B5ACF7292B28196C006D7641 /* TabBarCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */; };
 		B5ACF72B2B281A19006D7641 /* AuthCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */; };
+		B5ACF72D2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF72C2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift */; };
+		B5ACF72F2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF72E2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift */; };
+		B5ACF7312B284296006D7641 /* MyPageCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7302B284296006D7641 /* MyPageCoordinatorImpl.swift */; };
 		C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113D92B25359100B2C799 /* OnboardingViewModel.swift */; };
 		C00113DC2B2546DB00B2C799 /* PluTempButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113DB2B2546DB00B2C799 /* PluTempButton.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
@@ -199,6 +202,9 @@
 		B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashCoordinatorImpl.swift; sourceTree = "<group>"; };
 		B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinatorImpl.swift; sourceTree = "<group>"; };
 		B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinatorImpl.swift; sourceTree = "<group>"; };
+		B5ACF72C2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherAnswerCoordinatorImpl.swift; sourceTree = "<group>"; };
+		B5ACF72E2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerDetailCoordinatorImpl.swift; sourceTree = "<group>"; };
+		B5ACF7302B284296006D7641 /* MyPageCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C00113D92B25359100B2C799 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C00113DB2B2546DB00B2C799 /* PluTempButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluTempButton.swift; sourceTree = "<group>"; };
 		C0121A282B1347CA00D10EB0 /* Plu-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Plu-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -412,6 +418,9 @@
 				4A44666B2B28208D002D5BF7 /* RecordCoordinatorImpl.swift */,
 				C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */,
 				C07AB72A2B28380200C2E02C /* MyAnswerCoordinatorImpl.swift */,
+				B5ACF72C2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift */,
+				B5ACF72E2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift */,
+				B5ACF7302B284296006D7641 /* MyPageCoordinatorImpl.swift */,
 			);
 			path = CoordinatorImpl;
 			sourceTree = "<group>";
@@ -1027,6 +1036,7 @@
 				C05E26722B1D9BCF00D91BFA /* UILabel+.swift in Sources */,
 				B5ACF7222B2816C6006D7641 /* PopUpCoordinator.swift in Sources */,
 				B5ACF6C92B1EE26C006D7641 /* ElementColor.swift in Sources */,
+				B5ACF72F2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift in Sources */,
 				C0E93B5A2B20518B0098A822 /* TableSectionViewRegisterDequeueProtocol.swift in Sources */,
 				C05E26782B1D9D2900D91BFA /* StringConstant.swift in Sources */,
 				C0A2561D2B1ED99B0059AA7E /* MyPageHeaderView.swift in Sources */,
@@ -1094,6 +1104,7 @@
 				4AA747572B1D74A6004D0335 /* CGColor+.swift in Sources */,
 				C0E93B492B20358A0098A822 /* MypageAppVersionCellData.swift in Sources */,
 				C05E266B2B1D9B4C00D91BFA /* UIViewController+.swift in Sources */,
+				B5ACF7312B284296006D7641 /* MyPageCoordinatorImpl.swift in Sources */,
 				C05E26762B1D9CFB00D91BFA /* ScreenConstant.swift in Sources */,
 				4AA747672B25E6FD004D0335 /* ImageDummy.swift in Sources */,
 				C0121A2E2B1347CA00D10EB0 /* SceneDelegate.swift in Sources */,
@@ -1115,6 +1126,7 @@
 				C05E26652B1D9AEA00D91BFA /* Encodable+.swift in Sources */,
 				B5ACF7022B24A4B3006D7641 /* ResignDescriptionView.swift in Sources */,
 				B5ACF7202B281622006D7641 /* MyPageCoordinator.swift in Sources */,
+				B5ACF72D2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift in Sources */,
 				B5ACF6CB2B1EE3EC006D7641 /* Dummy.swift in Sources */,
 				B5ACF6CF2B1EECD0006D7641 /* OthersAnswerTableView.swift in Sources */,
 				C0682A822B25857200AD4DB4 /* PLUTextField.swift in Sources */,

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		C0682A852B25860D00AD4DB4 /* NicknameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A842B25860D00AD4DB4 /* NicknameManager.swift */; };
 		C0682A882B25862200AD4DB4 /* NicknameManagerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */; };
 		C07AB7272B2828A600C2E02C /* TabbarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */; };
+		C07AB7292B282E2D00C2E02C /* PopUpCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */; };
 		C0A2561D2B1ED99B0059AA7E /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561C2B1ED99B0059AA7E /* MyPageHeaderView.swift */; };
 		C0A2561F2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A2561E2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift */; };
 		C0A256232B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A256222B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift */; };
@@ -244,6 +245,7 @@
 		C0682A842B25860D00AD4DB4 /* NicknameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameManager.swift; sourceTree = "<group>"; };
 		C0682A872B25862200AD4DB4 /* NicknameManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameManagerStub.swift; sourceTree = "<group>"; };
 		C07AB7262B2828A600C2E02C /* TabbarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarCoordinator.swift; sourceTree = "<group>"; };
+		C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C0A2561C2B1ED99B0059AA7E /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
 		C0A2561E2B1EDC350059AA7E /* MyPageRoundSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageRoundSectionHeaderView.swift; sourceTree = "<group>"; };
 		C0A256222B1EDD550059AA7E /* MyPageAlarmTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAlarmTableViewCell.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 				B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */,
 				4A4466692B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift */,
 				4A44666B2B28208D002D5BF7 /* RecordCoordinatorImpl.swift */,
+				C07AB7282B282E2D00C2E02C /* PopUpCoordinatorImpl.swift */,
 			);
 			path = CoordinatorImpl;
 			sourceTree = "<group>";
@@ -1093,6 +1096,7 @@
 				C02C5DFE2B22E0780011F07C /* UIEdgeInsets+.swift in Sources */,
 				4A44666A2B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift in Sources */,
 				B5ACF70C2B26EC48006D7641 /* se+.swift in Sources */,
+				C07AB7292B282E2D00C2E02C /* PopUpCoordinatorImpl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -49,6 +49,10 @@
 		B5ACF71E2B2815EA006D7641 /* RecordCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */; };
 		B5ACF7202B281622006D7641 /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */; };
 		B5ACF7222B2816C6006D7641 /* PopUpCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */; };
+		B5ACF7252B2818D5006D7641 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7242B2818D5006D7641 /* AppCoordinator.swift */; };
+		B5ACF7272B281928006D7641 /* SplashCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */; };
+		B5ACF7292B28196C006D7641 /* TabBarCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */; };
+		B5ACF72B2B281A19006D7641 /* AuthCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */; };
 		C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113D92B25359100B2C799 /* OnboardingViewModel.swift */; };
 		C00113DC2B2546DB00B2C799 /* PluTempButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113DB2B2546DB00B2C799 /* PluTempButton.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
@@ -180,6 +184,10 @@
 		B5ACF71D2B2815EA006D7641 /* RecordCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinator.swift; sourceTree = "<group>"; };
 		B5ACF71F2B281622006D7641 /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7242B2818D5006D7641 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashCoordinatorImpl.swift; sourceTree = "<group>"; };
+		B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinatorImpl.swift; sourceTree = "<group>"; };
+		B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinatorImpl.swift; sourceTree = "<group>"; };
 		C00113D92B25359100B2C799 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C00113DB2B2546DB00B2C799 /* PluTempButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluTempButton.swift; sourceTree = "<group>"; };
 		C0121A282B1347CA00D10EB0 /* Plu-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Plu-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -351,6 +359,7 @@
 		B5ACF70D2B27F180006D7641 /* Coordinator */ = {
 			isa = PBXGroup;
 			children = (
+				B5ACF7232B2818C3006D7641 /* CoordinatorImpl */,
 				B5ACF70E2B27F18B006D7641 /* Interface */,
 			);
 			path = Coordinator;
@@ -371,6 +380,17 @@
 				B5ACF7212B2816C6006D7641 /* PopUpCoordinator.swift */,
 			);
 			path = Interface;
+			sourceTree = "<group>";
+		};
+		B5ACF7232B2818C3006D7641 /* CoordinatorImpl */ = {
+			isa = PBXGroup;
+			children = (
+				B5ACF7242B2818D5006D7641 /* AppCoordinator.swift */,
+				B5ACF7262B281928006D7641 /* SplashCoordinatorImpl.swift */,
+				B5ACF7282B28196C006D7641 /* TabBarCoordinatorImpl.swift */,
+				B5ACF72A2B281A19006D7641 /* AuthCoordinatorImpl.swift */,
+			);
+			path = CoordinatorImpl;
 			sourceTree = "<group>";
 		};
 		C0121A1F2B1347CA00D10EB0 = {
@@ -976,6 +996,7 @@
 				C05E26782B1D9D2900D91BFA /* StringConstant.swift in Sources */,
 				C0A2561D2B1ED99B0059AA7E /* MyPageHeaderView.swift in Sources */,
 				4AA747702B261221004D0335 /* PLUEverydayAnswerView.swift in Sources */,
+				B5ACF7272B281928006D7641 /* SplashCoordinatorImpl.swift in Sources */,
 				4AA747612B24B495004D0335 /* AnswerCautionView.swift in Sources */,
 				C0E93B522B2046030098A822 /* MyPageSectionHeaderHeight.swift in Sources */,
 				B5ACF7142B28133E006D7641 /* AuthCoordinator.swift in Sources */,
@@ -1010,13 +1031,16 @@
 				C05E268E2B1D9EC800D91BFA /* OthersAnswerViewController.swift in Sources */,
 				B5ACF6F12B22D116006D7641 /* RecordQuestionTableViewCell.swift in Sources */,
 				B5ACF6CD2B1EE735006D7641 /* AnswerView.swift in Sources */,
+				B5ACF7292B28196C006D7641 /* TabBarCoordinatorImpl.swift in Sources */,
 				B5ACF6D12B1EEECB006D7641 /* OtherAnswersDiffableModel.swift in Sources */,
+				B5ACF72B2B281A19006D7641 /* AuthCoordinatorImpl.swift in Sources */,
 				C0E93B472B20357B0098A822 /* MypageInfomationCellData.swift in Sources */,
 				B5ACF7102B27F193006D7641 /* Coordinator.swift in Sources */,
 				C0E93B432B2035580098A822 /* MyPageUserData.swift in Sources */,
 				B5ACF7122B2812E2006D7641 /* SplashCoordinator.swift in Sources */,
 				C0E93B402B2035370098A822 /* MyPageCell.swift in Sources */,
 				B5ACF71A2B28158E006D7641 /* OtherAnswersCoordinator.swift in Sources */,
+				B5ACF7252B2818D5006D7641 /* AppCoordinator.swift in Sources */,
 				C0E93B4E2B2036E50098A822 /* MyPageSection.swift in Sources */,
 				C0E0D4F72B26C7FC00840C0B /* NicknameEditViewController.swift in Sources */,
 				C05E265D2B1D9A5900D91BFA /* CollectionSectionViewRegisterDequeueProtocol.swift in Sources */,

--- a/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
+++ b/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
@@ -12,12 +12,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     var appCoordinator: AppCoordinatorImpl?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         Font.registerFonts()
-        let navigationController = UINavigationController(rootViewController: SplashViewController())
+        
+        let navigationController = UINavigationController()
+        appCoordinator = AppCoordinatorImpl(navigationController: navigationController)
+        appCoordinator?.startSplashCoordinator()
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
+++ b/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    var appCoordinator: AppCoordinatorImpl?
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {

--- a/Plu-iOS/Plu-iOS/DesignSystem/UIComponent/PLUButton.swift
+++ b/Plu-iOS/Plu-iOS/DesignSystem/UIComponent/PLUButton.swift
@@ -20,7 +20,7 @@ final class PLUButton: UIButton {
     
     private func setUpButton(config: UIButton.Configuration) {
         self.configuration = config
-        self.changesSelectionAsPrimaryAction = true
+//        self.changesSelectionAsPrimaryAction = true
     }
     
     @discardableResult

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AnswerDetailCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AnswerDetailCoordinatorImpl.swift
@@ -1,0 +1,33 @@
+//
+//  AnswerDetailCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import UIKit
+
+
+final class AnswerDetailCoordinatorImpl: AnswerDetailCoordinator {
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func showAnswerDetailViewController() {
+        let answerDetailViewController = AnswerDetailViewController()
+        self.navigationController.pushViewController(answerDetailViewController, animated: true)
+    }
+    
+    func pop() {
+        self.navigationController.popViewController(animated: true)
+        self.parentCoordinator?.childDidFinish(self)
+    }
+    
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinator.swift
@@ -1,0 +1,29 @@
+//
+//  AppCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+
+import UIKit
+
+final class AppCoordinator: Coordinator {
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func startSplashCoordinator() {
+        let splashCoordinator = SplashCoordinatorImpl(navigationController: navigationController)
+        children.removeAll()
+        splashCoordinator.parentCoordinator = self
+        children.append(splashCoordinator)
+        splashCoordinator.showSplashViewController()
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinatorImpl.swift
@@ -1,5 +1,5 @@
 //
-//  AppCoordinator.swift
+//  AppCoordinatorImpl.swift
 //  Plu-iOS
 //
 //  Created by 김민재 on 12/12/23.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class AppCoordinator: Coordinator {
+final class AppCoordinatorImpl: Coordinator {
     var parentCoordinator: Coordinator?
     
     var children: [Coordinator] = []

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
@@ -1,0 +1,39 @@
+//
+//  AuthCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import UIKit
+
+
+final class AuthCoordinatorImpl: AuthCoordinator {
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func showLoginViewController() {
+        <#code#>
+    }
+    
+    func showTabbarController() {
+        <#code#>
+    }
+    
+    func showOnboardingController() {
+        <#code#>
+    }
+    
+    func pop() {
+        <#code#>
+    }
+    
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
@@ -21,20 +21,21 @@ final class AuthCoordinatorImpl: AuthCoordinator {
     }
     
     func showLoginViewController() {
-        let loginViewController = LoginViewController()
+        let loginViewController = LoginViewController(coordinator: self)
         self.navigationController.pushViewController(loginViewController, animated: true)
     }
     
     func showTabbarController() {
-        print("ㅇㄹㄴㅇ")
+        let splashCoordinator = parentCoordinator as? SplashCoordinatorImpl
+        splashCoordinator?.showTabbarViewContoller()
     }
     
     func showOnboardingController() {
-        print("ㅇㄹㄴㅇ")
+        let onboardingViewController = OnboardingViewController(coordinator: self)
+        self.navigationController.pushViewController(onboardingViewController, animated: true)
     }
     
     func pop() {
-        print("ㅇㄹㄴㅇ")
+        self.navigationController.popViewController(animated: true)
     }
-    
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
@@ -21,19 +21,19 @@ final class AuthCoordinatorImpl: AuthCoordinator {
     }
     
     func showLoginViewController() {
-        <#code#>
+        print("ㅇㄹㄴㅇ")
     }
     
     func showTabbarController() {
-        <#code#>
+        print("ㅇㄹㄴㅇ")
     }
     
     func showOnboardingController() {
-        <#code#>
+        print("ㅇㄹㄴㅇ")
     }
     
     func pop() {
-        <#code#>
+        print("ㅇㄹㄴㅇ")
     }
     
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
@@ -21,7 +21,8 @@ final class AuthCoordinatorImpl: AuthCoordinator {
     }
     
     func showLoginViewController() {
-        print("ㅇㄹㄴㅇ")
+        let loginViewController = LoginViewController()
+        self.navigationController.pushViewController(loginViewController, animated: true)
     }
     
     func showTabbarController() {

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyAnswerCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyAnswerCoordinatorImpl.swift
@@ -1,0 +1,46 @@
+//
+//  MyAnswerCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/12.
+//
+
+import UIKit
+
+final class MyAnswerCoordinatorImpl: MyAnswerCoordinator {
+
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func showMyAnswerViewController() {
+        let myAnswerViewController = MyAnswerViewController(coordinator: self)
+        self.navigationController.pushViewController(myAnswerViewController, animated: true)
+    }
+    
+    func presentRegisterPopUpViewController() {
+        let popUpCoordinator = PopUpCoordinatorImpl(navigationController: self.navigationController)
+        popUpCoordinator.registerDelgate = self
+        popUpCoordinator.show(type: .register)
+        children.append(popUpCoordinator)
+    }
+    
+    func pop() {
+        self.navigationController.popViewController(animated: true)
+    }
+    
+}
+
+extension MyAnswerCoordinatorImpl: RegisterDelegate {
+    func register(_ input: Bool) {
+        print("나의답변을 등록한다고 합니다")
+        self.pop()
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyAnswerCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyAnswerCoordinatorImpl.swift
@@ -30,10 +30,12 @@ final class MyAnswerCoordinatorImpl: MyAnswerCoordinator {
         popUpCoordinator.registerDelgate = self
         popUpCoordinator.show(type: .register)
         children.append(popUpCoordinator)
+        popUpCoordinator.parentCoordinator = self
     }
     
     func pop() {
         self.navigationController.popViewController(animated: true)
+        self.parentCoordinator?.childDidFinish(self)
     }
     
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
@@ -5,41 +5,49 @@
 //  Created by 김민재 on 12/12/23.
 //
 
-import Foundation
 import UIKit
 
 final class MyPageCoordinatorImpl: MyPageCoordinator {
     func showMyPageViewController() {
-        <#code#>
+        let mypageViewController = MyPageViewController(coordinator: self)
+        self.navigationController.pushViewController(mypageViewController, animated: true)
     }
     
     func presentAlarmPopUpViewController() {
-        <#code#>
+        let popUpCoordinator = PopUpCoordinatorImpl(navigationController: self.navigationController)
+        popUpCoordinator.show(type: .alarm)
+        children.append(popUpCoordinator)
+        popUpCoordinator.parentCoordinator = self
     }
     
     func showProfileEditViewController() {
-        <#code#>
+        let profileEditViewController = NicknameEditViewController()
+        self.navigationController.pushViewController(profileEditViewController, animated: true)
     }
     
     func showResignViewController() {
-        <#code#>
+        let resignViewController = ResignViewController()
+        self.navigationController.pushViewController(resignViewController, animated: true)
     }
     
     
-    func pop<T: UIViewController>(type: T.Type) {
+    func pop<T: UIViewController>(taype: T.Type) {
         self.navigationController.popViewController(animated: true)
-        let rootType = type(of: navigationController.viewControllers.first)
-        if rootType == type {
-            // 첫번째
+        if type(of: self.navigationController.viewControllers.first!) == taype {
             parentCoordinator?.childDidFinish(self)
+            
         }
     }
     
     var parentCoordinator: Coordinator?
     
-    var children: [Coordinator]
+    var children: [Coordinator] = []
     
     var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
     
     
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
@@ -1,0 +1,45 @@
+//
+//  MyPageCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+import UIKit
+
+final class MyPageCoordinatorImpl: MyPageCoordinator {
+    func showMyPageViewController() {
+        <#code#>
+    }
+    
+    func presentAlarmPopUpViewController() {
+        <#code#>
+    }
+    
+    func showProfileEditViewController() {
+        <#code#>
+    }
+    
+    func showResignViewController() {
+        <#code#>
+    }
+    
+    
+    func pop<T: UIViewController>(type: T.Type) {
+        self.navigationController.popViewController(animated: true)
+        let rootType = type(of: navigationController.viewControllers.first)
+        if rootType == type {
+            // 첫번째
+            parentCoordinator?.childDidFinish(self)
+        }
+    }
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator]
+    
+    var navigationController: UINavigationController
+    
+    
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/OtherAnswerCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/OtherAnswerCoordinatorImpl.swift
@@ -1,0 +1,39 @@
+//
+//  OtherAnswerCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import UIKit
+
+final class OtherAnswerCoordinatorImpl: OtherAnswersCoordinator {
+    
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func showOtherAnswersViewController() {
+        let otherAnswerViewController = OthersAnswerViewController(coordinator: self)
+        self.navigationController.pushViewController(otherAnswerViewController, animated: true)
+    }
+    
+    func showAnswerDetailViewController() {
+        let answerDetailCoordinator = AnswerDetailCoordinatorImpl(navigationController: self.navigationController)
+        children.append(answerDetailCoordinator)
+        answerDetailCoordinator.parentCoordinator = self
+        answerDetailCoordinator.showAnswerDetailViewController()
+    }
+    
+    func pop() {
+        self.navigationController.popViewController(animated: true)
+        parentCoordinator?.childDidFinish(self)
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
@@ -7,12 +7,25 @@
 
 import UIKit
 
-protocol PopUpDelegate: AnyObject {
+protocol SelectMonthDelegate: AnyObject {
     func passYearAndMonth(_ input: String)
 }
 
+protocol AlarmDelegate: AnyObject {
+    func alarmAccept(_ input: Bool)
+}
+
+protocol RegisterDelegate: AnyObject {
+    func register(_ input: Bool)
+}
+
 final class PopUpCoordinatorImpl: PopUpCoordinator {
-    weak var delegate: PopUpDelegate?
+
+    
+    weak var selectMonthDelegate: SelectMonthDelegate?
+    weak var alarmDelegate: AlarmDelegate?
+    weak var registerDelgate: RegisterDelegate?
+    
     var parentCoordinator: Coordinator?
     
     var children: [Coordinator] = []
@@ -23,22 +36,38 @@ final class PopUpCoordinatorImpl: PopUpCoordinator {
         self.navigationController = navigationController
     }
     
-    func accept(type: PopUpType) {
+    
+    func show(type: PopUpType) {
         switch type {
         case .alarm:
-            let alarmPopUpViewController = 
+            let alarmPopUpViewController = AlarmPopUpViewController(coordinator: self)
+            self.navigationController.present(alarmPopUpViewController, animated: true)
         case .register:
-            <#code#>
-        case .selecMonth:
-            <#code#>
+            let registerPopUpViewController = RegisterPopUpViewController()
+            self.navigationController.present(registerPopUpViewController, animated: true)
+        case .selectMonth:
+            let selectMonthPopUpViewController = SelectMonthPopUpViewController()
+            self.navigationController.present(selectMonthPopUpViewController, animated: true)
         }
     }
     
-    func dismiss(yearAndMonth: String?) {
+    
+    func accept(type: PopUpType) {
+        switch type {
+        case .alarm:
+            self.alarmDelegate?.alarmAccept(true)
+        case .register:
+            self.registerDelgate?.register(true)
+        case .selectMonth:
+            self.selectMonthDelegate?.passYearAndMonth("날짜가입력되었습니다")
+        }
         self.navigationController.dismiss(animated: true) {
-            if let yearAndMonth = yearAndMonth {
-                self.delegate?.passYearAndMonth(yearAndMonth)
-            }
+            self.parentCoordinator?.childDidFinish(self)
+        }
+    }
+    
+    func dismiss() {
+        self.navigationController.dismiss(animated: true) {
             self.parentCoordinator?.childDidFinish(self)
         }
     }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
@@ -1,0 +1,45 @@
+//
+//  PopUpCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/12.
+//
+
+import UIKit
+
+protocol PopUpDelegate: AnyObject {
+    func passYearAndMonth(_ input: String)
+}
+
+final class PopUpCoordinatorImpl: PopUpCoordinator {
+    weak var delegate: PopUpDelegate?
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func accept(type: PopUpType) {
+        switch type {
+        case .alarm:
+            let alarmPopUpViewController = 
+        case .register:
+            <#code#>
+        case .selecMonth:
+            <#code#>
+        }
+    }
+    
+    func dismiss(yearAndMonth: String?) {
+        self.navigationController.dismiss(animated: true) {
+            if let yearAndMonth = yearAndMonth {
+                self.delegate?.passYearAndMonth(yearAndMonth)
+            }
+            self.parentCoordinator?.childDidFinish(self)
+        }
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
@@ -43,25 +43,26 @@ final class PopUpCoordinatorImpl: PopUpCoordinator {
             let alarmPopUpViewController = AlarmPopUpViewController(coordinator: self)
             self.navigationController.present(alarmPopUpViewController, animated: true)
         case .register:
-            let registerPopUpViewController = RegisterPopUpViewController()
+            let registerPopUpViewController = RegisterPopUpViewController(coordinator: self)
             self.navigationController.present(registerPopUpViewController, animated: true)
         case .selectMonth:
-            let selectMonthPopUpViewController = SelectMonthPopUpViewController()
+            let selectMonthPopUpViewController = SelectMonthPopUpViewController(coordinator: self)
             self.navigationController.present(selectMonthPopUpViewController, animated: true)
         }
     }
     
     
     func accept(type: PopUpType) {
-        switch type {
-        case .alarm:
-            self.alarmDelegate?.alarmAccept(true)
-        case .register:
-            self.registerDelgate?.register(true)
-        case .selectMonth:
-            self.selectMonthDelegate?.passYearAndMonth("날짜가입력되었습니다")
-        }
+        
         self.navigationController.dismiss(animated: true) {
+            switch type {
+            case .alarm:
+                self.alarmDelegate?.alarmAccept(true)
+            case .register:
+                self.registerDelgate?.register(true)
+            case .selectMonth:
+                self.selectMonthDelegate?.passYearAndMonth("날짜가 입력되었습니다")
+            }
             self.parentCoordinator?.childDidFinish(self)
         }
     }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
@@ -21,18 +21,18 @@ final class RecordCoordinatorImpl: RecordCoordinator {
     
     func showRecordViewController() {
         let recordViewController = RecordViewController()
-        self.navigationController?.pushViewController(recordViewController, animated: true)
+        self.navigationController.pushViewController(recordViewController, animated: true)
     }
     
     func showMyPageViewController() {
-        <#code#>
+        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
     
     func presentSelectMonthPopUpViewController() {
-        <#code#>
+        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
     
     func showAnswerDetailViewController() {
-        <#code#>
+        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
@@ -20,7 +20,7 @@ final class RecordCoordinatorImpl: RecordCoordinator {
     }
     
     func showRecordViewController() {
-        let recordViewController = RecordViewController()
+        let recordViewController = RecordViewController(coordinator: self)
         self.navigationController.pushViewController(recordViewController, animated: true)
     }
     
@@ -29,10 +29,25 @@ final class RecordCoordinatorImpl: RecordCoordinator {
     }
     
     func presentSelectMonthPopUpViewController() {
-        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
+        let popUpCoordinator = PopUpCoordinatorImpl(navigationController: navigationController)
+        popUpCoordinator.selectMonthDelegate = self
+        popUpCoordinator.parentCoordinator = self
+        children.append(popUpCoordinator)
+        
+        popUpCoordinator.show(type: .selectMonth)
     }
     
     func showAnswerDetailViewController() {
-        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
+        let answerDetailCoordinator = AnswerDetailCoordinatorImpl(navigationController: navigationController)
+        answerDetailCoordinator.showAnswerDetailViewController()
+        children.append(answerDetailCoordinator)
+        answerDetailCoordinator.parentCoordinator = self
     }
+}
+
+extension RecordCoordinatorImpl: SelectMonthDelegate {
+    func passYearAndMonth(_ input: String) {
+        print("필터 입력완료: \(input)")
+    }
+    
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
@@ -1,0 +1,38 @@
+//
+//  RecordCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 황찬미 on 2023/12/12.
+//
+
+import UIKit
+
+final class RecordCoordinatorImpl: RecordCoordinator {
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func showRecordViewController() {
+        let recordViewController = RecordViewController()
+        self.navigationController?.pushViewController(recordViewController, animated: true)
+    }
+    
+    func showMyPageViewController() {
+        <#code#>
+    }
+    
+    func presentSelectMonthPopUpViewController() {
+        <#code#>
+    }
+    
+    func showAnswerDetailViewController() {
+        <#code#>
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
@@ -21,7 +21,7 @@ final class SplashCoordinatorImpl: SplashCoordinator {
     }
     
     func showSplashViewController() {
-        let splashViewController = SplashViewController()
+        let splashViewController = SplashViewController(coordinator: self)
         self.navigationController.pushViewController(splashViewController, animated: true)
     }
     
@@ -29,7 +29,7 @@ final class SplashCoordinatorImpl: SplashCoordinator {
         let tabbarCoordinator = TabBarCoordinatorImpl(navigationController: navigationController)
         children.removeAll()
         tabbarCoordinator.parentCoordinator = self
-        //TODO: - methods
+        tabbarCoordinator.showTabbarController()
     }
     
     func showLoginViewController() {

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
@@ -1,0 +1,42 @@
+//
+//  SplashCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import UIKit
+
+
+final class SplashCoordinatorImpl: SplashCoordinator {
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func showSplashViewController() {
+        let splashViewController = SplashViewController()
+        self.navigationController.pushViewController(splashViewController, animated: true)
+    }
+    
+    func showTabbarViewContoller() {
+        let tabbarCoordinator = TabBarCoordinatorImpl(navigationController: navigationController)
+        children.removeAll()
+        tabbarCoordinator.parentCoordinator = self
+        //TODO: - methods
+    }
+    
+    func showLoginViewController() {
+        let authCoordinator = AuthCoordinatorImpl(navigationController: navigationController)
+        children.removeAll()
+        authCoordinator.parentCoordinator = self
+        children.append(authCoordinator)
+        authCoordinator.showLoginViewController()
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
@@ -22,7 +22,7 @@ final class SplashCoordinatorImpl: SplashCoordinator {
     
     func showSplashViewController() {
         let splashViewController = SplashViewController(coordinator: self)
-        self.navigationController.pushViewController(splashViewController, animated: true)
+        self.navigationController.pushViewController(splashViewController, animated: false)
     }
     
     func showTabbarViewContoller() {

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
@@ -19,4 +19,22 @@ final class TabBarCoordinatorImpl: Coordinator {
         self.navigationController = navigationController
     }
     
+    
+    
+}
+
+private extension TabBarCoordinatorImpl {
+    func startTodayQuestionCoordinator(_ navi: UINavigationController, from parent: Coordinator?) {
+        let todayQuestionCoordinator = TodayQuestionCoordinatorImpl(navigationController: navi)
+        todayQuestionCoordinator.parentCoordinator = parent
+        parent?.children.append(todayQuestionCoordinator)
+        todayQuestionCoordinator.showTodayQuestionViewController()
+    }
+    
+    func startRecordCoordinator(_ navi: UINavigationController, from parent: Coordinator?) {
+        let recordCoordinator = RecordCoordinatorImpl(navigationController: navi)
+        recordCoordinator.parentCoordinator = parent
+        parent?.children.append(recordCoordinator)
+        recordCoordinator.showRecordViewController()
+    }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
@@ -1,0 +1,22 @@
+//
+//  TabBarCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import UIKit
+
+
+final class TabBarCoordinatorImpl: Coordinator {
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
@@ -7,8 +7,12 @@
 
 import UIKit
 
+protocol TabbarCoordinator: Coordinator {
+    func showTabbarController()
+}
 
 final class TabBarCoordinatorImpl: Coordinator {
+
     var parentCoordinator: Coordinator?
     
     var children: [Coordinator] = []
@@ -19,14 +23,26 @@ final class TabBarCoordinatorImpl: Coordinator {
         self.navigationController = navigationController
     }
     
-    
-    
+    func showTabbarController() {
+        let tabbarController = TabbarViewController()
+        let todayQuestionNavigationController = UINavigationController()
+        let recordNavigationController = UINavigationController()
+        startRecordCoordinator(recordNavigationController, from: parentCoordinator)
+        startTodayQuestionCoordinator(todayQuestionNavigationController, from: parentCoordinator)
+        
+        tabbarController.viewControllers = [todayQuestionNavigationController, recordNavigationController]
+        
+        navigationController.viewControllers.removeAll()
+        navigationController.pushViewController(tabbarController, animated: true)
+        navigationController.isNavigationBarHidden = true
+    }
 }
 
 private extension TabBarCoordinatorImpl {
     func startTodayQuestionCoordinator(_ navi: UINavigationController, from parent: Coordinator?) {
         let todayQuestionCoordinator = TodayQuestionCoordinatorImpl(navigationController: navi)
         todayQuestionCoordinator.parentCoordinator = parent
+        navi.makeTabBar(title: "오늘의 질문", tabBarImg: ImageLiterals.TabBar.homeInActivated, tabBarSelectedImg: ImageLiterals.TabBar.homeActivated, renderingMode: .alwaysOriginal)
         parent?.children.append(todayQuestionCoordinator)
         todayQuestionCoordinator.showTodayQuestionViewController()
     }
@@ -34,6 +50,7 @@ private extension TabBarCoordinatorImpl {
     func startRecordCoordinator(_ navi: UINavigationController, from parent: Coordinator?) {
         let recordCoordinator = RecordCoordinatorImpl(navigationController: navi)
         recordCoordinator.parentCoordinator = parent
+        navi.makeTabBar(title: "일기 기록", tabBarImg: ImageLiterals.TabBar.recordInActivated, tabBarSelectedImg: ImageLiterals.TabBar.recordActivated, renderingMode: .alwaysOriginal)
         parent?.children.append(recordCoordinator)
         recordCoordinator.showRecordViewController()
     }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
@@ -7,13 +7,9 @@
 
 import UIKit
 
-protocol TabbarCoordinator: Coordinator {
-    func showTabbarController()
-}
+final class TabBarCoordinatorImpl: TabbarCoordinator {
 
-final class TabBarCoordinatorImpl: Coordinator {
-
-    var parentCoordinator: Coordinator?
+    weak var parentCoordinator: Coordinator?
     
     var children: [Coordinator] = []
     
@@ -33,7 +29,7 @@ final class TabBarCoordinatorImpl: Coordinator {
         tabbarController.viewControllers = [todayQuestionNavigationController, recordNavigationController]
         
         navigationController.viewControllers.removeAll()
-        navigationController.pushViewController(tabbarController, animated: true)
+        navigationController.pushViewController(tabbarController, animated: false)
         navigationController.isNavigationBarHidden = true
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -1,0 +1,42 @@
+//
+//  TodayQuestionCoordinatorImpl.swift
+//  Plu-iOS
+//
+//  Created by 황찬미 on 2023/12/12.
+//
+
+import UIKit
+
+final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
+    
+    var parentCoordinator: Coordinator?
+    
+    var children: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func showTodayQuestionViewController() {
+        let todayQuestionViewController = TodayQuestionViewController()
+        self.navigationController.pushViewController(todayQuestionViewController, animated: true)
+    }
+    
+    func showMyPageViewController() {
+        <#code#>
+    }
+    
+    func showMyAnswerViewController() {
+        <#code#>
+    }
+    
+    func showOtherAnswersViewController() {
+        <#code#>
+    }
+    
+    func presentAlarmPopUpViewController() {
+        <#code#>
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -20,7 +20,7 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     }
     
     func showTodayQuestionViewController() {
-        let todayQuestionViewController = TodayQuestionViewController()
+        let todayQuestionViewController = TodayQuestionViewController(coordinator: self)
         self.navigationController.pushViewController(todayQuestionViewController, animated: true)
     }
     
@@ -29,7 +29,9 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     }
     
     func showMyAnswerViewController() {
-        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
+        let myAnswerCoordinator = MyAnswerCoordinatorImpl(navigationController: self.navigationController)
+        myAnswerCoordinator.showMyAnswerViewController()
+        children.append(myAnswerCoordinator)
     }
     
     func showOtherAnswersViewController() {
@@ -37,7 +39,15 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     }
     
     func presentAlarmPopUpViewController() {
-        
-        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
+        let popUpCoordinator = PopUpCoordinatorImpl(navigationController: self.navigationController)
+        popUpCoordinator.alarmDelegate = self
+        popUpCoordinator.show(type: .alarm)
+        children.append(popUpCoordinator)
+    }
+}
+
+extension TodayQuestionCoordinatorImpl: AlarmDelegate {
+    func alarmAccept(_ input: Bool) {
+        print("알람 확인 버튼이 늘렸습니다")
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -25,18 +25,18 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     }
     
     func showMyPageViewController() {
-        <#code#>
+        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
     
     func showMyAnswerViewController() {
-        <#code#>
+        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
     
     func showOtherAnswersViewController() {
-        <#code#>
+        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
     
     func presentAlarmPopUpViewController() {
-        <#code#>
+        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -25,7 +25,10 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     }
     
     func showMyPageViewController() {
-        
+        let mypageCoordinator = MyPageCoordinatorImpl(navigationController: self.navigationController)
+        mypageCoordinator.showMyPageViewController()
+        children.append(mypageCoordinator)
+        mypageCoordinator.parentCoordinator = self
     }
     
     func showMyAnswerViewController() {

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -25,7 +25,7 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     }
     
     func showMyPageViewController() {
-        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
+        
     }
     
     func showMyAnswerViewController() {

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -37,6 +37,7 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     }
     
     func presentAlarmPopUpViewController() {
+        
         print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -32,10 +32,14 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
         let myAnswerCoordinator = MyAnswerCoordinatorImpl(navigationController: self.navigationController)
         myAnswerCoordinator.showMyAnswerViewController()
         children.append(myAnswerCoordinator)
+        myAnswerCoordinator.parentCoordinator = self
     }
     
     func showOtherAnswersViewController() {
-        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
+        let otherAnswerCoordinator = OtherAnswerCoordinatorImpl(navigationController: navigationController)
+        children.append(otherAnswerCoordinator)
+        otherAnswerCoordinator.parentCoordinator = self
+        otherAnswerCoordinator.showOtherAnswersViewController()
     }
     
     func presentAlarmPopUpViewController() {

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/AnswerDetailCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/AnswerDetailCoordinator.swift
@@ -1,0 +1,16 @@
+//
+//  AnswerDetailCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+
+protocol AnswerDetailCoordinator: Coordinator {
+    func showAnswerDetailViewController()
+    func pop()
+}
+
+

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/AuthCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/AuthCoordinator.swift
@@ -1,0 +1,16 @@
+//
+//  LoginCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+
+protocol AuthCoordinator: Coordinator {
+    func showLoginViewController()
+    func showTabbarController()
+    func showOnboardingController()
+    func pop()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/Coordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/Coordinator.swift
@@ -1,0 +1,29 @@
+//
+//  Coordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import UIKit
+
+protocol Coordinator : AnyObject {
+    var parentCoordinator: Coordinator? { get set }
+    var children: [Coordinator] { get set }
+    var navigationController : UINavigationController { get set }
+}
+
+extension Coordinator {
+    
+    /// Removing a coordinator inside a children. This call is important to prevent memory leak.
+    /// - Parameter coordinator: Coordinator that finished.
+    func childDidFinish(_ coordinator : Coordinator){
+        // Call this if a coordinator is done.
+        for (index, child) in children.enumerated() {
+            if child === coordinator {
+                children.remove(at: index)
+                break
+            }
+        }
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyAnswerCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyAnswerCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  MyAnswerCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+protocol MyAnswerCoordinator: Coordinator {
+    func showMyAnswerViewController()
+    func presentRegisterPopUpViewController()
+    func pop()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyPageCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyPageCoordinator.swift
@@ -1,0 +1,17 @@
+//
+//  MyPageCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+
+protocol MyPageCoordinator: Coordinator {
+    func showMyPageViewController()
+    func presentAlarmPopUpViewController()
+    func showProfileEditViewController()
+    func showResignViewController()
+    func pop()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyPageCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyPageCoordinator.swift
@@ -5,7 +5,7 @@
 //  Created by 김민재 on 12/12/23.
 //
 
-import Foundation
+import UIKit
 
 
 protocol MyPageCoordinator: Coordinator {
@@ -13,5 +13,5 @@ protocol MyPageCoordinator: Coordinator {
     func presentAlarmPopUpViewController()
     func showProfileEditViewController()
     func showResignViewController()
-    func pop()
+    func pop<T: UIViewController>(taype: T.Type)
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/OtherAnswersCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/OtherAnswersCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  OtherAnswersCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+protocol OtherAnswersCoordinator: Coordinator {
+    func showOtherAnswersViewController()
+    func showAnswerDetailViewController()
+    func pop()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/PopUpCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/PopUpCoordinator.swift
@@ -1,0 +1,34 @@
+//
+//  PopUpCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+
+//protocol AlarmPopUp: Coordinator {
+//    func
+//}
+//
+//protocol RegisterPopUp: Coordinator {
+//    
+//}
+//
+//protocol SelectMonthPopUp: Coordinator {
+//    
+//}
+
+@frozen
+enum PopUpType {
+    case alarm
+    case register
+    case selecMonth
+}
+
+protocol PopUpCoordinator: Coordinator {
+    func accept(type: PopUpType)
+    func dismiss()
+}
+

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/PopUpCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/PopUpCoordinator.swift
@@ -29,6 +29,6 @@ enum PopUpType {
 
 protocol PopUpCoordinator: Coordinator {
     func accept(type: PopUpType)
-    func dismiss()
+    func dismiss(yearAndMonth: String?)
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/PopUpCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/PopUpCoordinator.swift
@@ -24,11 +24,12 @@ import Foundation
 enum PopUpType {
     case alarm
     case register
-    case selecMonth
+    case selectMonth
 }
 
 protocol PopUpCoordinator: Coordinator {
+    func show(type: PopUpType)
     func accept(type: PopUpType)
-    func dismiss(yearAndMonth: String?)
+    func dismiss()
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/RecordCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/RecordCoordinator.swift
@@ -1,0 +1,16 @@
+//
+//  RecordCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+
+protocol RecordCoordinator: Coordinator {
+    func showRecordViewController()
+    func showMyPageViewController()
+    func presentSelectMonthPopUpViewController()
+    func showAnswerDetailViewController()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/SplashCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/SplashCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  SplashCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+protocol SplashCoordinator: Coordinator {
+    func showSplashViewController()
+    func showTabbarViewContoller()
+    func showLoginViewController()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/TabbarCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/TabbarCoordinator.swift
@@ -1,0 +1,12 @@
+//
+//  TabbarCoordinator.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/12.
+//
+
+import Foundation
+
+protocol TabbarCoordinator: Coordinator {
+    func showTabbarController()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/TodayQuestionCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/TodayQuestionCoordinator.swift
@@ -1,0 +1,17 @@
+//
+//  TodayQuestionCoordinator.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/12/23.
+//
+
+import Foundation
+
+protocol TodayQuestionCoordinator: Coordinator {
+    func showTodayQuestionViewController()
+    func showMyPageViewController()
+    func showMyAnswerViewController()
+    func showOtherAnswersViewController()
+    func presentAlarmPopUpViewController()
+}
+

--- a/Plu-iOS/Plu-iOS/Scenes/Login/LoginViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/LoginViewController.swift
@@ -35,7 +35,7 @@ final class LoginViewController: UIViewController {
         return collectionView
     }()
     
-    private var kakaoLoginButton = PLUButton(config: .filled())
+    private let kakaoLoginButton = PLUButton(config: .filled())
         .setText(text: "카카오로 시작하기", font: .title1)
         .setBackForegroundColor(backgroundColor: .kakaoYellow, foregroundColor: .black)
         .setImage(image: ImageLiterals.Tutorial.kakaoLogo, placement: .leading)
@@ -62,6 +62,7 @@ final class LoginViewController: UIViewController {
         setHierarchy()
         setLayout()
         setDataSource()
+        kakaoLoginButton.addTarget(self, action: #selector(loginButtonTapped), for: .touchUpInside)
     }
 }
 
@@ -108,6 +109,10 @@ private extension LoginViewController {
     func setDataSource() {
         self.tutorialCollectionView.dataSource = self
         self.tutorialCollectionView.delegate = self
+    }
+    
+    @objc func loginButtonTapped() {
+        self.coordinator.showOnboardingController()
     }
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/Login/LoginViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/LoginViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 
 final class LoginViewController: UIViewController {
     
+    var coordinator: AuthCoordinator
+    
     private let pageControl: UIPageControl = {
         let pageControl = UIPageControl()
         pageControl.numberOfPages = 3
@@ -33,17 +35,27 @@ final class LoginViewController: UIViewController {
         return collectionView
     }()
     
-    private let kakaoLoginButton = PLUButton(config: .filled())
+    private var kakaoLoginButton = PLUButton(config: .filled())
         .setText(text: "카카오로 시작하기", font: .title1)
         .setBackForegroundColor(backgroundColor: .kakaoYellow, foregroundColor: .black)
         .setImage(image: ImageLiterals.Tutorial.kakaoLogo, placement: .leading)
+    
     
     
     private let appleLoginButton = PLUButton(config: .filled())
         .setText(text: "Apple로 시작하기", font: .title1)
         .setBackForegroundColor(backgroundColor: .black, foregroundColor: .white)
         .setImage(image: ImageLiterals.Tutorial.AppleLogo, placement: .leading)
-
+    
+    init(coordinator: AuthCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
@@ -54,6 +66,7 @@ final class LoginViewController: UIViewController {
 }
 
 private extension LoginViewController {
+    
     func setUI() {
         self.view.backgroundColor = .designSystem(.background)
     }

--- a/Plu-iOS/Plu-iOS/Scenes/MyAnswer/MyAnswerViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyAnswer/MyAnswerViewController.swift
@@ -12,6 +12,9 @@ import SnapKit
 import Combine
 
 final class MyAnswerViewController: UIViewController {
+    
+    let coordinator: MyAnswerCoordinator
+    
     private var cancelBag = Set<AnyCancellable>()
     private let viewModel = MyAnswerViewModel()
     private let keyboardStatyeType = PassthroughSubject<KeyboardType, Never>()
@@ -23,6 +26,23 @@ final class MyAnswerViewController: UIViewController {
     private let underLine = PLUUnserLine(color: .gray100)
     private let bottomTextLabel = PLULabel(type: .body1R, color: .gray700, text: StringConstant.MyAnswer.bottomView.text)
     private let answerStateSwitch = UISwitch()
+    
+    private lazy var tempCompleteButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("임시완료버튼입니다", for: .normal)
+        button.backgroundColor = .designSystem(.error)
+        button.addTarget(self, action: #selector(completButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    init(coordinator: MyAnswerCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -76,6 +96,10 @@ final class MyAnswerViewController: UIViewController {
             make.bottom.equalTo(components.snp.top)
         }
     }
+    
+    @objc func completButtonTapped() {
+        self.coordinator.presentRegisterPopUpViewController()
+    }
 }
 
 // MARK: - UITextViewDelegate
@@ -103,6 +127,8 @@ private extension MyAnswerViewController {
     func setHierarchy() {
         view.addSubviews(everyDayAnswerView, answerTextView, answerCautionView, bottomView)
         bottomView.addSubviews(underLine, bottomTextLabel, answerStateSwitch)
+        /// 나중에 삭제
+        view.addSubview(tempCompleteButton)
     }
     
     func setLayout() {
@@ -143,6 +169,11 @@ private extension MyAnswerViewController {
         answerStateSwitch.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(20)
             make.centerY.equalToSuperview()
+        }
+        
+        tempCompleteButton.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.size.equalTo(150)
         }
     }
     

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/Enum/MyPageSection.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/Enum/MyPageSection.swift
@@ -21,7 +21,7 @@ extension MyPageSection {
                  .info(.init(.openSource)),
                  .info(.init(.privacy))],
                 [.appVersion(.init(.appVersion, appVersion: appVersion))],
-                [.info(.init(.logOut)),
-                 .info(.init(.resign))]]
+                [.exit(.init(.logOut)),
+                 .exit(.init(.resign))]]
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/View/MyPageTableView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/View/MyPageTableView.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+protocol MyPageHeaderDelgate: AnyObject {
+    func headerDidTapped()
+}
+
 final class MyPageTableView: UITableView {
+    
+    weak var myPageHeaderDelgate: MyPageHeaderDelgate?
     
     private let headerView = MyPageHeaderView()
 
@@ -17,6 +23,8 @@ final class MyPageTableView: UITableView {
         registerCell()
         registerSectionHeader()
         setHeader()
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
+        headerView.addGestureRecognizer(gesture)
     }
     
     required init?(coder: NSCoder) {
@@ -25,6 +33,10 @@ final class MyPageTableView: UITableView {
     
     func setTableHeader(nickName: String) {
         self.headerView.configure(nickName)
+    }
+    
+    @objc func viewTapped() {
+        self.myPageHeaderDelgate?.headerDidTapped()
     }
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/ViewController/MyPageViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/ViewController/MyPageViewController.swift
@@ -14,8 +14,20 @@ final class MyPageViewController: UIViewController {
     
     var tableData: [[MyPageSection]] = []
     
+    let coordinator: MyPageCoordinator
+    
     private let myPageTableView = MyPageTableView()
 
+    
+    init(coordinator: MyPageCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
@@ -44,6 +56,7 @@ private extension MyPageViewController {
     func setDelegate() {
         myPageTableView.dataSource = self
         myPageTableView.delegate = self
+        myPageTableView.myPageHeaderDelgate = self
     }
     
     func setMyPageFromUserData(input: MyPageUserData) {
@@ -97,7 +110,11 @@ extension MyPageViewController: UITableViewDataSource {
     }
 }
 
-extension MyPageViewController: UITableViewDelegate {
+extension MyPageViewController: UITableViewDelegate, MyPageHeaderDelgate {
+    func headerDidTapped() {
+        self.coordinator.showProfileEditViewController()
+    }
+    
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let section = tableData[section].first else { return UIView() }
         if case .alarm = section {
@@ -118,5 +135,13 @@ extension MyPageViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         print("\(indexPath.section+1)번째 section의 \(indexPath.row+1)번째 cell이 눌렸습니다")
+        switch tableData[indexPath.section][indexPath.row] {
+        case .exit(let data):
+            if data.title == "탈퇴하기" {
+                self.coordinator.showResignViewController()
+            }
+        default:
+            print("딴거")
+        }
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewController/OnboardingViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewController/OnboardingViewController.swift
@@ -13,6 +13,8 @@ import SnapKit
 
 final class OnboardingViewController: UIViewController {
     
+    var coordinator: AuthCoordinator
+    
     private let textFieldSubject = PassthroughSubject<String, Never>()
     private var cancelBag = Set<AnyCancellable>()
     
@@ -23,6 +25,15 @@ final class OnboardingViewController: UIViewController {
     private var signInButton = PluTempButton()
     
     private let viewModel = OnboardingViewModel(manager: NicknameManagerStub())
+    
+    init(coordinator: AuthCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -104,7 +115,8 @@ private extension OnboardingViewController {
         self.signInButton.addTarget(self, action: #selector(signInButtonTapped), for: .touchUpInside)
     }
     
-    @objc func signInButtonTapped() {
-        print("버튼이 눌렸습니다")
+    @objc
+    func signInButtonTapped() {
+        self.coordinator.showTabbarController()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/OthersAnswerViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/OthersAnswerViewController.swift
@@ -11,6 +11,8 @@ import UIKit
 import SnapKit
 
 final class OthersAnswerViewController: UIViewController {
+    
+    var coordinator: OtherAnswersCoordinator
         
     private let everydayAnswerView = PLUEverydayAnswerView()
     
@@ -30,6 +32,15 @@ final class OthersAnswerViewController: UIViewController {
     
     private var datasource: UITableViewDiffableDataSource<OtherAnswersSection, OtherAnswersItem>!
     
+    init(coordinator: OtherAnswersCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
@@ -39,6 +50,7 @@ final class OthersAnswerViewController: UIViewController {
         configUI(answer: OthersAnswer.dummmy())
         applySnapshot(OthersAnswer.dummmy())
         setButtonHandler()
+        setDelegate()
     }
 }
 
@@ -60,6 +72,10 @@ private extension OthersAnswerViewController {
             : ImageLiterals.Respone.arrowDownSmall600
             button.configuration = config
         })
+    }
+    
+    func setDelegate() {
+        self.answersTableView.delegate = self
     }
     
     func setLayout() {
@@ -124,5 +140,11 @@ private extension OthersAnswerViewController {
         self.everydayAnswerView.configureUI(answer: answer)
         self.elementImageView.image = answer.elementType.characterSmallImage
         self.totalAnswerCountLabel.text = "총 \(answer.answers.count)개"
+    }
+}
+
+extension OthersAnswerViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        self.coordinator.showAnswerDetailViewController()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/PopUp/AlarmPopUpViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PopUp/AlarmPopUpViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 
 final class AlarmPopUpViewController: PopUpDimmedViewController {
     
+    let coordinator: PopUpCoordinator
+    
     private let popUpBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .designSystem(.white)
@@ -43,10 +45,12 @@ final class AlarmPopUpViewController: PopUpDimmedViewController {
         return button
     }()
     
-    override init() {
+    init(coordinator: PopUpCoordinator) {
+        self.coordinator = coordinator
         super.init()
         setUp()
     }
+
     
     required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -54,10 +58,12 @@ final class AlarmPopUpViewController: PopUpDimmedViewController {
     
     @objc func agreeButtonTapped() {
         print("확인버튼 눌림")
+        self.coordinator.accept(type: .alarm)
     }
     
     @objc func disAgreeButtonTapped() {
         print("취소버튼 눌림")
+        self.coordinator.dismiss()
     }
     
 }

--- a/Plu-iOS/Plu-iOS/Scenes/PopUp/RegisterPopUpViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PopUp/RegisterPopUpViewController.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class RegisterPopUpViewController: PopUpDimmedViewController {
     
+    var coordinator: PopUpCoordinator
+    
     private let popUpBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .designSystem(.white)
@@ -42,7 +44,8 @@ final class RegisterPopUpViewController: PopUpDimmedViewController {
         return button
     }()
     
-    override init() {
+    init(coordinator: PopUpCoordinator) {
+        self.coordinator = coordinator
         super.init()
         setUp()
     }
@@ -52,11 +55,11 @@ final class RegisterPopUpViewController: PopUpDimmedViewController {
     }
     
     @objc func agreeButtonTapped() {
-        print("확인버튼 눌림")
+        self.coordinator.accept(type: .register)
     }
     
     @objc func disAgreeButtonTapped() {
-        print("취소버튼 눌림")
+        self.coordinator.dismiss()
     }
     
 }

--- a/Plu-iOS/Plu-iOS/Scenes/PopUp/SelectMonthPopUpViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PopUp/SelectMonthPopUpViewController.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class SelectMonthPopUpViewController: PopUpDimmedViewController {
     
+    var coordinator: PopUpCoordinator
+    
     private let popUpBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .designSystem(.white)
@@ -38,7 +40,8 @@ final class SelectMonthPopUpViewController: PopUpDimmedViewController {
         return button
     }()
     
-    override init() {
+    init(coordinator: PopUpCoordinator) {
+        self.coordinator = coordinator
         super.init()
         setUp()
     }
@@ -48,7 +51,7 @@ final class SelectMonthPopUpViewController: PopUpDimmedViewController {
     }
     
     @objc func agreeButtonTapped() {
-        print("확인버튼 눌림")
+        self.coordinator.accept(type: .selectMonth)
     }
     
     @objc func dateChange(_ datePicker: UIDatePicker) {

--- a/Plu-iOS/Plu-iOS/Scenes/Record/RecordViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Record/RecordViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 
 final class RecordViewController: UIViewController {
     
+    var coordinator: RecordCoordinator
+    
     private let totalCountLabel = PLULabel(type: .subHead1, color: .gray600, backgroundColor: .background)
     
     private let dateFilterButton = PLUButton(config: .bordered())
@@ -22,12 +24,23 @@ final class RecordViewController: UIViewController {
     private let questionTableView = OthersAnswerTableView(tableViewType: .recordQuestions)
     
     private lazy var datasource = RecordDiffableDataSource(tableView: self.questionTableView)
-
+    
+    init(coordinator: RecordCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
         setHierarchy()
         setLayout()
+        setDelegate()
+        setAction()
         applySnapshot(.dummy())
         configureUI(record: .dummy())
     }
@@ -39,6 +52,17 @@ final class RecordViewController: UIViewController {
 }
 
 private extension RecordViewController {
+    func setDelegate() {
+        self.questionTableView.delegate = self
+    }
+    
+    func setAction() {
+        let action = UIAction { action in
+            self.coordinator.presentSelectMonthPopUpViewController()
+        }
+        dateFilterButton.addAction(action, for: .touchUpInside)
+    }
+    
     func setUI() {
         view.backgroundColor = .designSystem(.background)
     }
@@ -78,3 +102,10 @@ private extension RecordViewController {
         self.datasource.apply(snapshot)
     }
 }
+
+extension RecordViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        self.coordinator.showAnswerDetailViewController()
+    }
+}
+

--- a/Plu-iOS/Plu-iOS/Scenes/Splash/SplashViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Splash/SplashViewController.swift
@@ -50,7 +50,7 @@ final class SplashViewController: UIViewController {
     }
     
     @objc func tap() {
-        self.coordinator.showTabbarViewContoller()
+        self.coordinator.showLoginViewController()
     }
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/Splash/SplashViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Splash/SplashViewController.swift
@@ -12,6 +12,17 @@ import SnapKit
 
 final class SplashViewController: UIViewController {
     
+    let coordinator: SplashCoordinator
+    
+    init(coordinator: SplashCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     private let eyeImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
@@ -23,12 +34,23 @@ final class SplashViewController: UIViewController {
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
+    
+    lazy var button: UIButton = {
+        let button = UIButton()
+        button.setTitle("sofjisofjsoi", for: .normal)
+        button.addTarget(self, action: #selector(tap), for: .touchUpInside)
+        return button
+    }()
 
     public override func viewDidLoad() {
         super.viewDidLoad()
         selectRandomElement()
         setHierarchy()
         setLayout()
+    }
+    
+    @objc func tap() {
+        self.coordinator.showTabbarViewContoller()
     }
 }
 
@@ -44,7 +66,7 @@ private extension SplashViewController {
     }
     
     func setHierarchy() {
-        view.addSubviews(eyeImageView, wordMarkView)
+        view.addSubviews(eyeImageView, wordMarkView, button)
     }
     
     func setLayout() {
@@ -60,6 +82,10 @@ private extension SplashViewController {
             make.centerX.equalToSuperview()
             make.width.equalTo(view.snp.width).multipliedBy(0.20)
             make.height.equalTo(wordMarkView.snp.width).multipliedBy(0.74)
+        }
+        button.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.size.equalTo(100)
         }
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Tabbar/TabbarViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Tabbar/TabbarViewController.swift
@@ -11,11 +11,9 @@ import UIKit
 import SnapKit
 
 final class TabbarViewController: UITabBarController {
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setTabBar()
         setTabBarAppearance()
         setTabBarUI()
     }
@@ -28,23 +26,6 @@ final class TabbarViewController: UITabBarController {
 }
 
 private extension TabbarViewController {
-    func setTabBar() {
-        let todayQuestion = makeTabBar(viewController: TodayQuestionViewController(),
-                                       title: "오늘의 질문",
-                                       tabBarImg: ImageLiterals.TabBar.homeInActivated,
-                                       tabBarSelectedImg: ImageLiterals.TabBar.homeActivated,
-                                       renderingMode: .alwaysOriginal)
-        
-        let myAnswer = makeTabBar(viewController: MyAnswerViewController(),
-                                  title: "일기 기록",
-                                  tabBarImg: ImageLiterals.TabBar.recordInActivated,
-                                  tabBarSelectedImg: ImageLiterals.TabBar.recordActivated,
-                                  renderingMode: .alwaysOriginal)
-        
-        let tabs = [todayQuestion, myAnswer]
-        
-        self.setViewControllers(tabs, animated: false)
-    }
     
     func setTabBarHeight() {
         tabBar.frame.size.height = 100
@@ -75,18 +56,19 @@ private extension TabbarViewController {
     }
 }
 
-private extension TabbarViewController {
-    func makeTabBar(viewController: UIViewController,
-                                title: String,
-                                tabBarImg: UIImage,
-                                tabBarSelectedImg: UIImage,
-                                renderingMode: UIImage.RenderingMode) -> UIViewController {
-            
-            let tab = UINavigationController(rootViewController: viewController)
-            tab.isNavigationBarHidden = true
-            tab.tabBarItem = UITabBarItem(title: title,
-                                          image: tabBarImg.withRenderingMode(renderingMode),
-                                          selectedImage: tabBarSelectedImg.withRenderingMode(renderingMode))
-            return tab
-        }
+extension UINavigationController {
+    func makeTabBar(title: String,
+                    tabBarImg: UIImage,
+                    tabBarSelectedImg: UIImage,
+                    renderingMode: UIImage.RenderingMode) {
+        
+        self.isNavigationBarHidden = true
+        self.tabBarItem = UITabBarItem(title: title,
+                                       image: tabBarImg.withRenderingMode(renderingMode),
+                                       selectedImage: tabBarSelectedImg.withRenderingMode(renderingMode))
+    }
+    
+    
 }
+
+

--- a/Plu-iOS/Plu-iOS/Scenes/TodayQuestion/TodayQuestionViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/TodayQuestion/TodayQuestionViewController.swift
@@ -106,6 +106,7 @@ private extension TodayQuestionViewController {
     
     func setAddTarget() {
         myAnswerButton.addTarget(self, action: #selector(writeButtonTapped), for: .touchUpInside)
+        everyAnswerButtom.addTarget(self, action: #selector(everyAnswerTapped), for: .touchUpInside)
     }
     
     func setDelegate() {
@@ -129,5 +130,9 @@ private extension TodayQuestionViewController {
     
     @objc func writeButtonTapped() {
         self.coordinator.showMyAnswerViewController()
+    }
+    
+    @objc func everyAnswerTapped() {
+        self.coordinator.showOtherAnswersViewController()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/TodayQuestion/TodayQuestionViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/TodayQuestion/TodayQuestionViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 
 final class TodayQuestionViewController: UIViewController {
     
+    let coordinator: TodayQuestionCoordinator
+    
     private lazy var questionCharcterImage = UIImageView(image: self.setRandomImage())
     private let questionLabel = PLULabel(type: .head1,
                                          color: .gray700,
@@ -26,7 +28,16 @@ final class TodayQuestionViewController: UIViewController {
         .setText(text: StringConstant.TodayQuestion.everyAnswer.text, font: .title1)
         .setBackForegroundColor(backgroundColor: .gray600, foregroundColor: .gray50)
     private let explanationLabel = PLULabel(type: .caption, color: .gray300, text: StringConstant.TodayQuestion.explanation.text)
-
+    
+    init(coordinator: TodayQuestionCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -36,6 +47,11 @@ final class TodayQuestionViewController: UIViewController {
         setAddTarget()
         setDelegate()
         setButtonHandler()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.coordinator.presentAlarmPopUpViewController()
     }
 }
 
@@ -89,7 +105,7 @@ private extension TodayQuestionViewController {
     }
     
     func setAddTarget() {
-        
+        myAnswerButton.addTarget(self, action: #selector(writeButtonTapped), for: .touchUpInside)
     }
     
     func setDelegate() {
@@ -109,5 +125,9 @@ private extension TodayQuestionViewController {
     func setRandomImage() -> UIImage {
         let randomIndex = Int(arc4random_uniform(UInt32(ImageDummy.imageList.count)))
         return ImageDummy.imageList[randomIndex]
+    }
+    
+    @objc func writeButtonTapped() {
+        self.coordinator.showMyAnswerViewController()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/TodayQuestion/TodayQuestionViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/TodayQuestion/TodayQuestionViewController.swift
@@ -29,6 +29,14 @@ final class TodayQuestionViewController: UIViewController {
         .setBackForegroundColor(backgroundColor: .gray600, foregroundColor: .gray50)
     private let explanationLabel = PLULabel(type: .caption, color: .gray300, text: StringConstant.TodayQuestion.explanation.text)
     
+    lazy var tempMyPageButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("마이페이지", for: .normal)
+        button.backgroundColor = .designSystem(.error)
+        button.addTarget(self, action: #selector(mypageButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
     init(coordinator: TodayQuestionCoordinator) {
         self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
@@ -49,9 +57,13 @@ final class TodayQuestionViewController: UIViewController {
         setButtonHandler()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         self.coordinator.presentAlarmPopUpViewController()
+    }
+    
+    @objc func mypageButtonTapped() {
+        self.coordinator.showMyPageViewController()
     }
 }
 
@@ -62,6 +74,7 @@ private extension TodayQuestionViewController {
     
     func setHierarchy() {
         view.addSubviews(questionCharcterImage, questionLabel, explanationView, seeYouTommorowImage, myAnswerButton, everyAnswerButtom, explanationLabel)
+        view.addSubview(tempMyPageButton)
     }
     
     func setLayout() {
@@ -101,6 +114,11 @@ private extension TodayQuestionViewController {
         explanationLabel.snp.makeConstraints { make in
             make.bottom.equalToSuperview().inset(124)
             make.centerX.equalToSuperview()
+        }
+        
+        tempMyPageButton.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.size.equalTo(100)
         }
     }
     


### PR DESCRIPTION
## 🌱 작업한 내용
## 도입 이유
Coordinator가 없는 기존의 방법을 사용한다면 하위 요소인 ViewController가 상위 요소인 NavigationController에게 user flow를 명령하는 "명령의 흐름이 역전된 모습"을 가집니다. 뿐만 아니라 `화면전환`에 대한 책임은 UI에 대한 책임을 지닌 ViewController의 책임에 벗어나기에 화면전환에 대한 책임을 전담하는 객체가 필요하다고 판단되었습니다. 그리고 이것이 곧 Coordinator 객체입니다.

`Plu`에서도 `라이온하트`와 마찬가지로 Testable한 객체를 위해 단일 책임 객체를 추구하기 때문에 ViewController에 걸맞지 않은 화면전환에 대한 책임을 **Coordinator Pattern을 통해서 ViewController로부터 분리시키고자 합니다.**

## 설계
![image](https://github.com/Team-Plu/Plu-iOS/assets/60292150/a634710e-58a3-444f-9ded-144907986055)

1. `AppCoordinator`의 child로 `SplashCoordinator`가 존재합니다
2. `SplashCoordinator`은 `AuthCoordinator`와 `TabBarCoordinator`를 child로 가집니다
- `Loginviewcontroller`에서 `OnboardingViewcontroller`의 화면전환을 `Authcoordinator`가 담당합니다
- `OnboardingViewController`혹은 `LoginViewcontroller`에서 `TabBarController`로의 전환은 `SplashCoordinator`가 담당합니다
3. `TabBarCoordinator`는 각 tab에 있는 coordinator를 시작해주는 역할을 담당합니다 (TabBar내부의 coordinator의 parent는 tabbar coordinator가 아닌 `SplashCoordinator`로 설정해줍니다)
4. `AnswerDetail`과 `MyAnswer`는 `AnswerCoordinator`라는 하나의 논리적 흐름으로 묶을 수 있었지만, `AnswerDetail`은 여러 곳에서 도달할 수 있는 곳이기에 `AnswerDetail`을 별도의 Coordinator를 통해서 따로 구성했습니다.
5. `PopUpCoordinator` 또한 아래와 같은 이유로 따로 구성했습니다.

## PopUpCoordinator

### 1. PopUp Coordinator 채택 이유

Plu에는 총 3가지 종류의 PopUp이 존재하는데 ViewController형태로 존재하며 present로 UI를 보여주기에 따로 PopUp의 화면전환을 관리해주는 Coordinator가 있어야한다고 생각했습니다

만약에 특정 flow에 popUp이 무조건 보여지는 방식이었다면 따로 Coordinator를 구성하지 않았겠지만 조건에따라 PopUpCoordinator를 호출하는것이 재사용측면에서 이점이 있다고 생각했습니다

특정 상황에 PopUp을 띄워야하는 경우에 PopUpCoordinator에게 PopUpType을 넘겨주고 show메서드를 호출하면 해당 PopUp이 UI에 보여지는 구조를 가지고 있습니다

```swift
enum PopUpType { case alarm, register, selectMonth }

protocol PopUpCoordinator: Coordinator {
    func show(type: PopUpType)
    func accept(type: PopUpType)
    func dismiss()
}
```

### 2. PopUp Coordinator 구조

PopUp을 띄우고나면 확인버튼과 취소버튼이 있고 확인의 경우엔 특정 action의 data를 넘겨줘야하기에 delegate로 action의 시점과 데이터를 넘겨주어야합니다, action을 넘기는 방식으로는 coordiator가 combine을 import하지 않게 하기 위해서 delegate pattern을 사용했습니다

```swift
protocol SelectMonthDelegate: AnyObject {
    func passYearAndMonth(_ input: String)
}

protocol AlarmDelegate: AnyObject {
    func alarmAccept(_ input: Bool)
}

protocol RegisterDelegate: AnyObject {
    func register(_ input: Bool)
}
```

UI/UX상으로 dismiss가 된 후에 특정 action을 취하는 방식이 적절하다 생각해 UI로직의 순서를 dismiss가 끝나면 completion handler내에서 로직을 수행하도록 구현했습니다, PopUp을 show하고 accept버튼을 누르는 경우에 view를 띄우고 내린다는 action자체는 동일하기에 하나의 interface로 묶고 type을 통해 특정 PopUp의 action을 정의해줬습니다

```swift
func accept(type: PopUpType) {
    self.navigationController.dismiss(animated: true) {
        switch type {
        case .alarm:
            self.alarmDelegate?.alarmAccept(true)
        case .register:
            self.registerDelgate?.register(true)
        case .selectMonth:
            self.selectMonthDelegate?.passYearAndMonth("날짜가 입력되었습니다")
        }
        self.parentCoordinator?.childDidFinish(self)
    }
}
```

취소버튼을 눌렀을때도 마찬가지의 순서로 로직이 수행되도록 구현했습니다

```swift
func dismiss() {
    self.navigationController.dismiss(animated: true) {
        self.parentCoordinator?.childDidFinish(self)
    }
}
```

PopUpCoordinator의 경우, 하나의 VC가 dismiss되면 coordinator flow가 종료되기에 확인버튼을 누르거나 취소버튼을 누른경우 parent의 child coordinator array에서 찾아 제거해주는로직이 필요합니다(memory leak 방지를 위해)

---

### Coordinator 사용 방법

1. ViewController는 하나의 Coordinator를 가지고 있고, Coordinator는 여러개의 ViewController를 가질 수 있습니다.

```swift
protocol TodayQuestionCoordinator: Coordinator {
    func showTodayQuestionViewController()
    func showMyPageViewController()
    func showMyAnswerViewController()
    func showOtherAnswersViewController()
    func presentAlarmPopUpViewController()
}
```

2.  ViewController에서 Coordinator 프로토콜을 채택하고 있는 객체를 의존성 주입받습니다.

```swift
final class TodayQuestionViewController: UIViewController {
    
    let coordinator: TodayQuestionCoordinator
    init(coordinator: TodayQuestionCoordinator) {
        self.coordinator = coordinator
        super.init(nibName: nil, bundle: nil)
    }
		...
}
```

3. 버튼 클릭시 coordinator 객체를 통해 화면전환 메서드를 호출합니다. (호출부)

```swift
@objc func writeButtonTapped() {
      self.coordinator.showMyAnswerViewController()
}
    
@objc func everyAnswerTapped() {
	    self.coordinator.showOtherAnswersViewController()
}
```

4. (구현부)CoordinatorImpl 클래스에서 실제 interface를 구현해 주고, 해당 메서드 내에서 화면 전환 로직을 구현해 줍니다. 이 때 parent와 child관계를 규명해주기 위해서 생성한 Coordinator의 parent를 self로 할당하고, childCoordinator배열에 생성한 Coordinator를 append 합니다.

```swift
func showMyPageViewController() {
     let mypageCoordinator = MyPageCoordinatorImpl(navigationController: self.navigationController)
     mypageCoordinator.showMyPageViewController()
     children.append(mypageCoordinator)
     mypageCoordinator.parentCoordinator = self
}

func showOtherAnswersViewController() {
     let otherAnswerCoordinator = OtherAnswerCoordinatorImpl(navigationController: navigationController)
     children.append(otherAnswerCoordinator)
     otherAnswerCoordinator.parentCoordinator = self
     otherAnswerCoordinator.showOtherAnswersViewController()
 }
```

현재는 러프한 1차 `Coordinator` 적용한 상태입니다. 추후 필요한 디자인패턴이나 DIP등을 적용할 예정입니다.


## 📮 관련 이슈

- Resolved: #33
