### PR TITLE
[REFACTOR] 기존 Coordinator의 parent/child구조를 self-deallocation로 리팩터링(#35)

### DIFF
--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AnswerDetailCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AnswerDetailCoordinatorImpl.swift
@@ -10,24 +10,19 @@ import UIKit
 
 final class AnswerDetailCoordinatorImpl: AnswerDetailCoordinator {
     
-    var parentCoordinator: Coordinator?
+    weak var navigationController: UINavigationController?
     
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func showAnswerDetailViewController() {
         let answerDetailViewController = AnswerDetailViewController()
-        self.navigationController.pushViewController(answerDetailViewController, animated: true)
+        self.navigationController?.pushViewController(answerDetailViewController, animated: true)
     }
     
     func pop() {
-        self.navigationController.popViewController(animated: true)
-        self.parentCoordinator?.childDidFinish(self)
+        self.navigationController?.popViewController(animated: true)
     }
     
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AppCoordinatorImpl.swift
@@ -9,21 +9,14 @@
 import UIKit
 
 final class AppCoordinatorImpl: Coordinator {
-    var parentCoordinator: Coordinator?
+    weak var navigationController: UINavigationController?
     
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func startSplashCoordinator() {
-        let splashCoordinator = SplashCoordinatorImpl(navigationController: navigationController)
-        children.removeAll()
-        splashCoordinator.parentCoordinator = self
-        children.append(splashCoordinator)
+        let splashCoordinator = SplashCoordinatorImpl(navigationController: self.navigationController)
         splashCoordinator.showSplashViewController()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/AuthCoordinatorImpl.swift
@@ -10,32 +10,28 @@ import UIKit
 
 final class AuthCoordinatorImpl: AuthCoordinator {
     
-    var parentCoordinator: Coordinator?
+    weak var navigationController: UINavigationController?
     
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func showLoginViewController() {
         let loginViewController = LoginViewController(coordinator: self)
-        self.navigationController.pushViewController(loginViewController, animated: true)
+        self.navigationController?.pushViewController(loginViewController, animated: true)
     }
     
     func showTabbarController() {
-        let splashCoordinator = parentCoordinator as? SplashCoordinatorImpl
-        splashCoordinator?.showTabbarViewContoller()
+        let tabbarCoordinator = TabBarCoordinatorImpl(navigationController: self.navigationController)
+        tabbarCoordinator.showTabbarController()
     }
     
     func showOnboardingController() {
         let onboardingViewController = OnboardingViewController(coordinator: self)
-        self.navigationController.pushViewController(onboardingViewController, animated: true)
+        self.navigationController?.pushViewController(onboardingViewController, animated: true)
     }
     
     func pop() {
-        self.navigationController.popViewController(animated: true)
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyAnswerCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyAnswerCoordinatorImpl.swift
@@ -8,34 +8,26 @@
 import UIKit
 
 final class MyAnswerCoordinatorImpl: MyAnswerCoordinator {
-
     
-    var parentCoordinator: Coordinator?
+    weak var navigationController: UINavigationController?
     
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func showMyAnswerViewController() {
         let myAnswerViewController = MyAnswerViewController(coordinator: self)
-        self.navigationController.pushViewController(myAnswerViewController, animated: true)
+        self.navigationController?.pushViewController(myAnswerViewController, animated: true)
     }
     
     func presentRegisterPopUpViewController() {
         let popUpCoordinator = PopUpCoordinatorImpl(navigationController: self.navigationController)
         popUpCoordinator.registerDelgate = self
         popUpCoordinator.show(type: .register)
-        children.append(popUpCoordinator)
-        popUpCoordinator.parentCoordinator = self
     }
     
     func pop() {
-        self.navigationController.popViewController(animated: true)
-        self.parentCoordinator?.childDidFinish(self)
+        self.navigationController?.popViewController(animated: true)
     }
     
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
@@ -8,45 +8,36 @@
 import UIKit
 
 final class MyPageCoordinatorImpl: MyPageCoordinator {
+    
+    weak var navigationController: UINavigationController?
+    
+    init(navigationController: UINavigationController?) {
+        self.navigationController = navigationController
+    }
+    
     func showMyPageViewController() {
         let mypageViewController = MyPageViewController(coordinator: self)
-        self.navigationController.pushViewController(mypageViewController, animated: true)
+        self.navigationController?.pushViewController(mypageViewController, animated: true)
     }
     
     func presentAlarmPopUpViewController() {
         let popUpCoordinator = PopUpCoordinatorImpl(navigationController: self.navigationController)
         popUpCoordinator.show(type: .alarm)
-        children.append(popUpCoordinator)
-        popUpCoordinator.parentCoordinator = self
     }
     
     func showProfileEditViewController() {
         let profileEditViewController = NicknameEditViewController()
-        self.navigationController.pushViewController(profileEditViewController, animated: true)
+        self.navigationController?.pushViewController(profileEditViewController, animated: true)
     }
     
     func showResignViewController() {
         let resignViewController = ResignViewController()
-        self.navigationController.pushViewController(resignViewController, animated: true)
+        self.navigationController?.pushViewController(resignViewController, animated: true)
     }
     
     
-    func pop<T: UIViewController>(taype: T.Type) {
-        self.navigationController.popViewController(animated: true)
-        if type(of: self.navigationController.viewControllers.first!) == taype {
-            parentCoordinator?.childDidFinish(self)
-            
-        }
-    }
-    
-    var parentCoordinator: Coordinator?
-    
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
-        self.navigationController = navigationController
+    func pop() {
+        self.navigationController?.popViewController(animated: true)
     }
     
     

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/OtherAnswerCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/OtherAnswerCoordinatorImpl.swift
@@ -9,31 +9,23 @@ import UIKit
 
 final class OtherAnswerCoordinatorImpl: OtherAnswersCoordinator {
     
+    weak var navigationController: UINavigationController?
     
-    var parentCoordinator: Coordinator?
-    
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func showOtherAnswersViewController() {
         let otherAnswerViewController = OthersAnswerViewController(coordinator: self)
-        self.navigationController.pushViewController(otherAnswerViewController, animated: true)
+        self.navigationController?.pushViewController(otherAnswerViewController, animated: true)
     }
     
     func showAnswerDetailViewController() {
         let answerDetailCoordinator = AnswerDetailCoordinatorImpl(navigationController: self.navigationController)
-        children.append(answerDetailCoordinator)
-        answerDetailCoordinator.parentCoordinator = self
         answerDetailCoordinator.showAnswerDetailViewController()
     }
     
     func pop() {
-        self.navigationController.popViewController(animated: true)
-        parentCoordinator?.childDidFinish(self)
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/PopUpCoordinatorImpl.swift
@@ -26,13 +26,9 @@ final class PopUpCoordinatorImpl: PopUpCoordinator {
     weak var alarmDelegate: AlarmDelegate?
     weak var registerDelgate: RegisterDelegate?
     
-    var parentCoordinator: Coordinator?
+    weak var navigationController: UINavigationController?
     
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
@@ -41,20 +37,20 @@ final class PopUpCoordinatorImpl: PopUpCoordinator {
         switch type {
         case .alarm:
             let alarmPopUpViewController = AlarmPopUpViewController(coordinator: self)
-            self.navigationController.present(alarmPopUpViewController, animated: true)
+            self.navigationController?.present(alarmPopUpViewController, animated: true)
         case .register:
             let registerPopUpViewController = RegisterPopUpViewController(coordinator: self)
-            self.navigationController.present(registerPopUpViewController, animated: true)
+            self.navigationController?.present(registerPopUpViewController, animated: true)
         case .selectMonth:
             let selectMonthPopUpViewController = SelectMonthPopUpViewController(coordinator: self)
-            self.navigationController.present(selectMonthPopUpViewController, animated: true)
+            self.navigationController?.present(selectMonthPopUpViewController, animated: true)
         }
     }
     
     
     func accept(type: PopUpType) {
         
-        self.navigationController.dismiss(animated: true) {
+        self.navigationController?.dismiss(animated: true) {
             switch type {
             case .alarm:
                 self.alarmDelegate?.alarmAccept(true)
@@ -63,13 +59,10 @@ final class PopUpCoordinatorImpl: PopUpCoordinator {
             case .selectMonth:
                 self.selectMonthDelegate?.passYearAndMonth("날짜가 입력되었습니다")
             }
-            self.parentCoordinator?.childDidFinish(self)
         }
     }
     
     func dismiss() {
-        self.navigationController.dismiss(animated: true) {
-            self.parentCoordinator?.childDidFinish(self)
-        }
+        self.navigationController?.dismiss(animated: true)
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/RecordCoordinatorImpl.swift
@@ -9,39 +9,32 @@ import UIKit
 
 final class RecordCoordinatorImpl: RecordCoordinator {
     
-    var parentCoordinator: Coordinator?
+    weak var navigationController: UINavigationController?
     
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func showRecordViewController() {
         let recordViewController = RecordViewController(coordinator: self)
-        self.navigationController.pushViewController(recordViewController, animated: true)
+        self.navigationController?.pushViewController(recordViewController, animated: true)
     }
     
     func showMyPageViewController() {
-        print("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅")
+        let myPageCoordinator = MyPageCoordinatorImpl(navigationController: self.navigationController)
+        myPageCoordinator.showMyPageViewController()
     }
     
     func presentSelectMonthPopUpViewController() {
-        let popUpCoordinator = PopUpCoordinatorImpl(navigationController: navigationController)
+        let popUpCoordinator = PopUpCoordinatorImpl(navigationController: self.navigationController)
         popUpCoordinator.selectMonthDelegate = self
-        popUpCoordinator.parentCoordinator = self
-        children.append(popUpCoordinator)
         
         popUpCoordinator.show(type: .selectMonth)
     }
     
     func showAnswerDetailViewController() {
-        let answerDetailCoordinator = AnswerDetailCoordinatorImpl(navigationController: navigationController)
+        let answerDetailCoordinator = AnswerDetailCoordinatorImpl(navigationController: self.navigationController)
         answerDetailCoordinator.showAnswerDetailViewController()
-        children.append(answerDetailCoordinator)
-        answerDetailCoordinator.parentCoordinator = self
     }
 }
 
@@ -49,5 +42,4 @@ extension RecordCoordinatorImpl: SelectMonthDelegate {
     func passYearAndMonth(_ input: String) {
         print("필터 입력완료: \(input)")
     }
-    
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/SplashCoordinatorImpl.swift
@@ -9,34 +9,25 @@ import UIKit
 
 
 final class SplashCoordinatorImpl: SplashCoordinator {
+
+    weak var navigationController: UINavigationController?
     
-    var parentCoordinator: Coordinator?
-    
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func showSplashViewController() {
         let splashViewController = SplashViewController(coordinator: self)
-        self.navigationController.pushViewController(splashViewController, animated: false)
+        self.navigationController?.pushViewController(splashViewController, animated: false)
     }
     
     func showTabbarViewContoller() {
-        let tabbarCoordinator = TabBarCoordinatorImpl(navigationController: navigationController)
-        children.removeAll()
-        tabbarCoordinator.parentCoordinator = self
+        let tabbarCoordinator = TabBarCoordinatorImpl(navigationController: self.navigationController)
         tabbarCoordinator.showTabbarController()
     }
     
     func showLoginViewController() {
         let authCoordinator = AuthCoordinatorImpl(navigationController: navigationController)
-        children.removeAll()
-        authCoordinator.parentCoordinator = self
-        children.append(authCoordinator)
         authCoordinator.showLoginViewController()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TabBarCoordinatorImpl.swift
@@ -8,14 +8,10 @@
 import UIKit
 
 final class TabBarCoordinatorImpl: TabbarCoordinator {
-
-    weak var parentCoordinator: Coordinator?
     
-    var children: [Coordinator] = []
+    weak var navigationController: UINavigationController?
     
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
@@ -23,31 +19,27 @@ final class TabBarCoordinatorImpl: TabbarCoordinator {
         let tabbarController = TabbarViewController()
         let todayQuestionNavigationController = UINavigationController()
         let recordNavigationController = UINavigationController()
-        startRecordCoordinator(recordNavigationController, from: parentCoordinator)
-        startTodayQuestionCoordinator(todayQuestionNavigationController, from: parentCoordinator)
+        startRecordCoordinator(recordNavigationController)
+        startTodayQuestionCoordinator(todayQuestionNavigationController)
         
         tabbarController.viewControllers = [todayQuestionNavigationController, recordNavigationController]
         
-        navigationController.viewControllers.removeAll()
-        navigationController.pushViewController(tabbarController, animated: false)
-        navigationController.isNavigationBarHidden = true
+        navigationController?.viewControllers.removeAll()
+        navigationController?.pushViewController(tabbarController, animated: false)
+        navigationController?.isNavigationBarHidden = true
     }
 }
 
 private extension TabBarCoordinatorImpl {
-    func startTodayQuestionCoordinator(_ navi: UINavigationController, from parent: Coordinator?) {
+    func startTodayQuestionCoordinator(_ navi: UINavigationController) {
         let todayQuestionCoordinator = TodayQuestionCoordinatorImpl(navigationController: navi)
-        todayQuestionCoordinator.parentCoordinator = parent
         navi.makeTabBar(title: "오늘의 질문", tabBarImg: ImageLiterals.TabBar.homeInActivated, tabBarSelectedImg: ImageLiterals.TabBar.homeActivated, renderingMode: .alwaysOriginal)
-        parent?.children.append(todayQuestionCoordinator)
         todayQuestionCoordinator.showTodayQuestionViewController()
     }
     
-    func startRecordCoordinator(_ navi: UINavigationController, from parent: Coordinator?) {
+    func startRecordCoordinator(_ navi: UINavigationController) {
         let recordCoordinator = RecordCoordinatorImpl(navigationController: navi)
-        recordCoordinator.parentCoordinator = parent
         navi.makeTabBar(title: "일기 기록", tabBarImg: ImageLiterals.TabBar.recordInActivated, tabBarSelectedImg: ImageLiterals.TabBar.recordActivated, renderingMode: .alwaysOriginal)
-        parent?.children.append(recordCoordinator)
         recordCoordinator.showRecordViewController()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/TodayQuestionCoordinatorImpl.swift
@@ -9,39 +9,29 @@ import UIKit
 
 final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
     
-    var parentCoordinator: Coordinator?
+    weak var navigationController: UINavigationController?
     
-    var children: [Coordinator] = []
-    
-    var navigationController: UINavigationController
-    
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController?) {
         self.navigationController = navigationController
     }
     
     func showTodayQuestionViewController() {
         let todayQuestionViewController = TodayQuestionViewController(coordinator: self)
-        self.navigationController.pushViewController(todayQuestionViewController, animated: true)
+        self.navigationController?.pushViewController(todayQuestionViewController, animated: true)
     }
     
     func showMyPageViewController() {
         let mypageCoordinator = MyPageCoordinatorImpl(navigationController: self.navigationController)
         mypageCoordinator.showMyPageViewController()
-        children.append(mypageCoordinator)
-        mypageCoordinator.parentCoordinator = self
     }
     
     func showMyAnswerViewController() {
         let myAnswerCoordinator = MyAnswerCoordinatorImpl(navigationController: self.navigationController)
         myAnswerCoordinator.showMyAnswerViewController()
-        children.append(myAnswerCoordinator)
-        myAnswerCoordinator.parentCoordinator = self
     }
     
     func showOtherAnswersViewController() {
-        let otherAnswerCoordinator = OtherAnswerCoordinatorImpl(navigationController: navigationController)
-        children.append(otherAnswerCoordinator)
-        otherAnswerCoordinator.parentCoordinator = self
+        let otherAnswerCoordinator = OtherAnswerCoordinatorImpl(navigationController: self.navigationController)
         otherAnswerCoordinator.showOtherAnswersViewController()
     }
     
@@ -49,7 +39,6 @@ final class TodayQuestionCoordinatorImpl: TodayQuestionCoordinator {
         let popUpCoordinator = PopUpCoordinatorImpl(navigationController: self.navigationController)
         popUpCoordinator.alarmDelegate = self
         popUpCoordinator.show(type: .alarm)
-        children.append(popUpCoordinator)
     }
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/Coordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/Coordinator.swift
@@ -8,22 +8,22 @@
 import UIKit
 
 protocol Coordinator : AnyObject {
-    var parentCoordinator: Coordinator? { get set }
-    var children: [Coordinator] { get set }
-    var navigationController : UINavigationController { get set }
+//    var parentCoordinator: Coordinator? { get set }
+//    var children: [Coordinator] { get set }
+    var navigationController : UINavigationController? { get set }
 }
 
-extension Coordinator {
-    
-    /// Removing a coordinator inside a children. This call is important to prevent memory leak.
-    /// - Parameter coordinator: Coordinator that finished.
-    func childDidFinish(_ coordinator : Coordinator){
-        // Call this if a coordinator is done.
-        for (index, child) in children.enumerated() {
-            if child === coordinator {
-                children.remove(at: index)
-                break
-            }
-        }
-    }
-}
+//extension Coordinator {
+//    
+//    /// Removing a coordinator inside a children. This call is important to prevent memory leak.
+//    /// - Parameter coordinator: Coordinator that finished.
+//    func childDidFinish(_ coordinator : Coordinator){
+//        // Call this if a coordinator is done.
+//        for (index, child) in children.enumerated() {
+//            if child === coordinator {
+//                children.remove(at: index)
+//                break
+//            }
+//        }
+//    }
+//}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/Coordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/Coordinator.swift
@@ -8,22 +8,5 @@
 import UIKit
 
 protocol Coordinator : AnyObject {
-//    var parentCoordinator: Coordinator? { get set }
-//    var children: [Coordinator] { get set }
     var navigationController : UINavigationController? { get set }
 }
-
-//extension Coordinator {
-//    
-//    /// Removing a coordinator inside a children. This call is important to prevent memory leak.
-//    /// - Parameter coordinator: Coordinator that finished.
-//    func childDidFinish(_ coordinator : Coordinator){
-//        // Call this if a coordinator is done.
-//        for (index, child) in children.enumerated() {
-//            if child === coordinator {
-//                children.remove(at: index)
-//                break
-//            }
-//        }
-//    }
-//}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyPageCoordinator.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/Interface/MyPageCoordinator.swift
@@ -13,5 +13,5 @@ protocol MyPageCoordinator: Coordinator {
     func presentAlarmPopUpViewController()
     func showProfileEditViewController()
     func showResignViewController()
-    func pop<T: UIViewController>(taype: T.Type)
+    func pop()
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/LoginViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/LoginViewController.swift
@@ -145,7 +145,7 @@ extension LoginViewController: UICollectionViewDataSource {
         let title = Login.allCases[indexPath.item].title
         let image = Login.allCases[indexPath.item].image
         
-        cell.configureCell(image: image, text: title)
+        cell.configureUI(image: image, text: title)
         return cell
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/TutorialCollectionViewCell.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/TutorialCollectionViewCell.swift
@@ -52,7 +52,7 @@ final class TutorialCollectionViewCell: UICollectionViewCell, CollectionViewCell
         }
     }
     
-    func configureCell(image: UIImage, text: String) {
+    func configureUI(image: UIImage, text: String) {
         self.screenshotImageView.image = image
         self.tutorialLabel.text = text
     }

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/Cell/MyPageAlarmTableViewCell.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/Cell/MyPageAlarmTableViewCell.swift
@@ -54,7 +54,7 @@ final class MyPageAlarmTableViewCell: UITableViewCell, TableViewCellRegisterDequ
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(_ input: MyPageAlarmCellData) {
+    func configureUI(_ input: MyPageAlarmCellData) {
         self.alarmSwitch.isOn = input.acceptAlarm
         self.cellTitle.text = input.title
     }

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/Cell/MyPageAppVersionTableViewCell.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/Cell/MyPageAppVersionTableViewCell.swift
@@ -37,7 +37,7 @@ final class MyPageAppVersionTableViewCell: UITableViewCell, TableViewCellRegiste
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(_ input: MypageAppVersionCellData) {
+    func configureUI(_ input: MypageAppVersionCellData) {
         self.cellTitle.text = input.title
         self.appVersion.text = input.appVersion
     }

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/Cell/MyPageGeneralTableViewCell.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/Cell/MyPageGeneralTableViewCell.swift
@@ -37,7 +37,7 @@ final class MyPageGeneralTableViewCell: UITableViewCell, TableViewCellRegisterDe
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(_ input: MyPageCell) {
+    func configureUI(_ input: MyPageCell) {
         self.cellTitle.text = input.title
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/View/MyPageHeaderView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/View/MyPageHeaderView.swift
@@ -43,7 +43,7 @@ final class MyPageHeaderView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(_ input: String) {
+    func configureUI(_ input: String) {
         self.nickNameLabel.text = input
     }
 

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/View/MyPageTableView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/View/MyPageTableView.swift
@@ -32,7 +32,7 @@ final class MyPageTableView: UITableView {
     }
     
     func setTableHeader(nickName: String) {
-        self.headerView.configure(nickName)
+        self.headerView.configureUI(nickName)
     }
     
     @objc func viewTapped() {

--- a/Plu-iOS/Plu-iOS/Scenes/MyPage/ViewController/MyPageViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/MyPage/ViewController/MyPageViewController.swift
@@ -84,19 +84,19 @@ extension MyPageViewController: UITableViewDataSource {
         switch tableData[indexPath.section][indexPath.row] {
         case .alarm(let data):
             let cell = MyPageAlarmTableViewCell.dequeueReusableCell(to: tableView)
-            cell.configure(data)
+            cell.configureUI(data)
             return cell
         case .info(let data):
             let cell = MyPageGeneralTableViewCell.dequeueReusableCell(to: tableView)
-            cell.configure(data)
+            cell.configureUI(data)
             return cell
         case .appVersion(let data):
             let cell = MyPageAppVersionTableViewCell.dequeueReusableCell(to: tableView)
-            cell.configure(data)
+            cell.configureUI(data)
             return cell
         case .exit(let data):
             let cell = MyPageGeneralTableViewCell.dequeueReusableCell(to: tableView)
-            cell.configure(data)
+            cell.configureUI(data)
             return cell
         }
     }

--- a/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/OthersAnswerViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/OthersAnswerViewController.swift
@@ -119,7 +119,7 @@ private extension OthersAnswerViewController {
             case .answer(let answer, let element):
                 let cell = AnswerTableViewCell.dequeueReusableCell(to: self.answersTableView)
                 
-                cell.configureView(answer, element: element)
+                cell.configureUI(answer, element: element)
                 return cell
             }
         })

--- a/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/TableView/AnswerTableViewCell.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/TableView/AnswerTableViewCell.swift
@@ -42,7 +42,7 @@ final class AnswerTableViewCell: UITableViewCell, TableViewCellRegisterDequeuePr
         }
     }
     
-    func configureView(_ answer: Answer, element: Elements) {
-        self.answerView.configureView(answer, element: element)
+    func configureUI(_ answer: Answer, element: Elements) {
+        self.answerView.configureUI(answer, element: element)
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/View/AnswerView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/OthersAnswer/View/AnswerView.swift
@@ -56,7 +56,7 @@ final class AnswerView: UIView {
         }
     }
     
-    func configureView(_ answer: Answer, element: Elements) {
+    func configureUI(_ answer: Answer, element: Elements) {
         let empathyCount = answer.empathyCount > 999 ? "999+" : answer.empathyCount.description
         
         answerLabel.text = answer.answerText

--- a/Plu-iOS/Plu-iOS/Scenes/Record/RecordDiffableDataSource.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Record/RecordDiffableDataSource.swift
@@ -15,7 +15,7 @@ final class RecordDiffableDataSource: UITableViewDiffableDataSource<RecordSectio
             switch itemIdentifier {
             case .question(let question):
                 let cell = RecordQuestionTableViewCell.dequeueReusableCell(to: tableView)
-                cell.configureCell(question)
+                cell.configureUI(question)
                 return cell
             }
         }

--- a/Plu-iOS/Plu-iOS/Scenes/Record/TableViewCell/RecordQuestionTableViewCell.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Record/TableViewCell/RecordQuestionTableViewCell.swift
@@ -42,7 +42,7 @@ class RecordQuestionTableViewCell: UITableViewCell, TableViewCellRegisterDequeue
         }
     }
     
-    func configureCell(_ question: Question) {
+    func configureUI(_ question: Question) {
         self.questionView.configureUI(question)
     }
 


### PR DESCRIPTION
## [#35] REFACTOR : 기존 Coordinator의 parent/child구조를 self-deallocation로 리팩터링

## 🌱 작업한 내용
### 참여인원 @ffalswo2 @cchanmi @kimscastle @LentoAssai
- Plu 코어타임에 Coordinator를 적용하는 와중에 기존 child와 parent구조의 Coordinator pattern에 대한 의문이들어 self-deallocation방식에 대한 논의를 진행하고 최종적으로 self-deallocation방식의 coordinator pattern으로 재적용하기로 결정했습니다
- PR Point에 Self-Deallocation을 적용하면서 나왔던(6시간의 토론결과...)를 기록해놓곘습니다

## 🌱 PR Point
### 0. Self-Deallocation방식이란?
> 참고했던 medium글입니다
[Coordinator pattern in Swift without child coordinators](https://medium.com/vptech/coordinator-pattern-in-swift-without-child-coordinators-42d482d15975)

---

### 1. Self-Deallocation 방식을 채택하게된 이유
1. coordinator는 design pattern으로 `단순히 화면전환을 담당해주는 객체를 통한 로직 수행` 의 역할만으로 의미가 충분하다고 생각했습니다. 어떠한 방식이더라도 단순히 화면전환을 수행해주는 담당객체로서의 역할만 하고있다면 `디자인패턴` 으로서의 coordinator는 의미가 있다고 생각해서 기본의 coodinator방식을 self-deallocation방식으로 변경했습니다

> 만약에 coordinator가 아키텍처였다면 특정한 구조(parent/child)를 가져가는 것이 맞지만 coordinator는 design pattern이기에 기존방식과 다른 방식이더라도 화면전환을 담당하는 객체라는 조건이 충족된다면 방식의 차이가 맞고 틀림을 결정하지 않을것이라고 생각했습니다

---

2. coordinator의 생명주기가 viewcontroller나 viewModel과 일치하지 않는 경우가 (현재 앱 구조상)없기때문에 vc와 vm의 생명주기와 별개로 coodinator의 생명주기를 따로 관리해주는 방식(manual 하게 coordinator를 deallocation해주는 방식)은 현재 구조상 side-effect(memory leak)이 발생할 가능성이 매우 높습니다.

> [!WARNING]
> Coordinator를 설계할 때 우리는 직관에 따라 논리적 흐름으로 ViewController들을 분류하여 묶었는데, 이런 논리적 흐름만으로 분류할 것이 아니라 코드 레벨로 기능을 생각해서 Coordinator를 설계한 후에 parent와 child를 정의했다면 VC 혹은 VM과 Coordinator간의 생명주기가 달라지게 되는 경우도 있지 않을까요? Coordinator를 설계할 때 놓친게 있지 않을까요?

> [!NOTE]
> Coordinator Pattern이 본래 제안된 이유, 본질을 생각해보면, Coordinator가 없는 기존의 방법을 사용한다면 하위 요소인 ViewController가 상위 요소인 NavigationController에게 user flow를 명령하는 명령의 흐름이 역전된 모습일 뿐만 아니라 UI를 관할하는 ViewController책임에 벗어나기에 화면전환에 대한 책임을 전담하는 Coordinator객체를 만들자! 가 본질입니다
>
> 따라서 코드 단위로 기능적인 것 까지 염두에 두고 Coordinator를 분류하는 것은 Coordinator Pattern이 해결하고자 하는 문제의 본질에서 벗어난 것으로 판단했습니다. 
>
> 결국 논리적 흐름에 따라 Coordinator를 설계한 것은 잘못되지 않았고, 결국 이는 하나의 User flow를 관리하는 NavigationController의 생명주기와 Coordinator는 대응되는 개념이고 이들의 생명주기는 운명을 같이할 수 밖에 없습니다.


---

3. 기존방식(paren와 child를 사용하는 방식)은 tree구조의 형태로 제시되어진 design pattern였으며 상위 노드와 하위노드의 계층관계를 명시하기위해 child와 parent를 사용했습니다. 하지만 개념적인 상위하위노드가 존재하는 트리구조가 아니라면 반대로 parent와 child가 필요없을 수 있습니다

> tree구조 이기에 parent와 child를 통한 계층관계 확립이 가능했고 이를 통해 coordinator의 생명주기를 따로 관리해주는 방식이었는데 tree구조(상하관계인 tree)를 채택하지 않은 coordinator라면 parent와 child가 필요없고 이로인해 coordinator의 생명주기를 vc와 vm의 생명주기와 일치시켜 self-deallocation한 coordinator를 구성할 수 있습니다

> [!WARNING]
> self-deallocation방식이 기존방식인 parent/child에 비해 어떤점이 다르고 어떤 부분이 장점으로 다가오나요?

> [!NOTE]
> 기존방식을 parent/child라고 하고 채택방식을 self-deallocation이라고 하겠습니다.
기존방식은 parent coodinator에 child배열에 coordinator를 append해주는 방식으로 인해 vc나 vm이 할당해제가 되어도 배열에서 rc를 증가시켜 메모리에서 해제되지 않는 방식이었습니다.
>
> 물론 vc나 vm의 생명주기와 따로 관리하는게 안전할 수 있지만 대부분의 상황에서(해당앱에서는 모든상황에서) vc나 vm의 생명주기가 끝났는데 coordiantor가 메모리에 남아있어야할 상황도 이유도 없었습니다.
> 
> 명시적으로 해당 coordinator에서 flow가 끝나는 vc일때 따로 child array에서 해당 coordinator를 manual하게 제거해줘야하는데 이부분은 놓치기 쉽고, 놓친다면 메모리에 필요없는 coodinator가 남아있게됩니다(앱이 종료될때까지) 하지만 parent/child를 사용했을 때의 이러한 critical한 문제점을 감안하면서까지 계층이있는 tree형태의 coordinator pattern이 가지는 장점이 없다고 생각했습니다.
(추후에 해당방식이 가지는 단점을 상쇄할 만큼의 장점, 상황을 마주하면 다시 변경할 예정입니다😀)
>
> tree구조가 가지는 장점이 없다면 이로인한 단점만 가지는 구조가 기존방식이라고 생각해서 채택방식을 통해 기존의 tree구조는 아니지만 흐름상 어색하지 않고 memory leak이 발생할 가능성이(해당 앱에서만큼은) 없는 방식으로 선택하게 되었습니다

---

### 2. 결론

따라서 maual하게 deallocation을 하게되면 발생할 수있는 memory leak의 가능성, 앱의 계층을 설계할때의 자연스러운 흐름(login에서 onboarding으로 flow가 흘러간다고 생각하고 설계하는게 자연스럽지 login에서 상위 auth에게 onboarding을 요청하는건 약간 부자연스러움)을 고려했을때 기존의 parent/child방식의 coordintor 방식이 아닌 self-deallocation방식으로 coordinator 구조를 변경했습니다

> 추후에 해당방식이 가지는 문제점을 마주하게되면 기존방식과 비교하는 과정을 통해 다시한번 리팩터링을 진행할예정입니다
> 

> [!WARNING]
> parent와 child를 통해 부모와 자식 관계를 규명하는 **Tree구조**(기존방식) vs Self deallocating 방식의 **non -Tree구조**에 대한 고민


> [!NOTE]
> Tree구조와 non-Tree구조를 비교했을 때 Tree구조를 유지했을 때 non-tree구조에 비해 기술적으로 얻을 수 있는 이점이 있다라고 느끼지 못했습니다.
>
> 처음에는 parent/child방식은 Tree구조를 사용해서 부모와 자식을 규명하기 때문에 자연스러운 인간의 사고 흐름에 더 가깝게 표현되기에 더 익숙하고 이해하기 쉽고, Self deallocating방식은 non-Tree방식이기에 새로 해당 방식을 접하는 사람에게 매우 불친절하고, 사용하기에 앞서 모든 user flow를 완벽히 숙지해야하는 단점이 존재할 것이라고 생각했습니다.
>
> 하지만, Self-deallocating방식으로 한다 했을 때에도, 우리가 자료구조에서 정의하는 트리의 정의에는 맞지 않을 수 있지만 user flow상으로 충분히 트리로 표현될 수 있고 이 정도만으로도 개발자간에 소통하는데에 어떠한 지장도 없다고 판단했습니다.

## 📮 관련 이슈
- Resolved: #35 
