### PR TITLE
[FEAT] 1차 UI추가작업 (Custom NavigationBar) (#40)

### DIFF
--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B5ACF72D2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF72C2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift */; };
 		B5ACF72F2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF72E2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift */; };
 		B5ACF7312B284296006D7641 /* MyPageCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7302B284296006D7641 /* MyPageCoordinatorImpl.swift */; };
+		B5ACF7392B2A8ADC006D7641 /* PLUNavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACF7382B2A8ADC006D7641 /* PLUNavigationBarView.swift */; };
 		C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113D92B25359100B2C799 /* OnboardingViewModel.swift */; };
 		C00113DC2B2546DB00B2C799 /* PluTempButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113DB2B2546DB00B2C799 /* PluTempButton.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
@@ -205,6 +206,7 @@
 		B5ACF72C2B283CD8006D7641 /* OtherAnswerCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherAnswerCoordinatorImpl.swift; sourceTree = "<group>"; };
 		B5ACF72E2B283D23006D7641 /* AnswerDetailCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerDetailCoordinatorImpl.swift; sourceTree = "<group>"; };
 		B5ACF7302B284296006D7641 /* MyPageCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinatorImpl.swift; sourceTree = "<group>"; };
+		B5ACF7382B2A8ADC006D7641 /* PLUNavigationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLUNavigationBarView.swift; sourceTree = "<group>"; };
 		C00113D92B25359100B2C799 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C00113DB2B2546DB00B2C799 /* PluTempButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluTempButton.swift; sourceTree = "<group>"; };
 		C0121A282B1347CA00D10EB0 /* Plu-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Plu-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -504,6 +506,7 @@
 				C05E267B2B1D9E1E00D91BFA /* Onboarding */,
 				C05E267A2B1D9E1900D91BFA /* Login */,
 				C05E26792B1D9E1000D91BFA /* Splash */,
+				B5ACF7382B2A8ADC006D7641 /* PLUNavigationBarView.swift */,
 			);
 			path = Scenes;
 			sourceTree = "<group>";
@@ -1136,6 +1139,7 @@
 				C02C5DFE2B22E0780011F07C /* UIEdgeInsets+.swift in Sources */,
 				4A44666A2B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift in Sources */,
 				B5ACF70C2B26EC48006D7641 /* se+.swift in Sources */,
+				B5ACF7392B2A8ADC006D7641 /* PLUNavigationBarView.swift in Sources */,
 				C07AB7292B282E2D00C2E02C /* PopUpCoordinatorImpl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1305,7 +1309,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Z225784MRD;
+				DEVELOPMENT_TEAM = AXN37CP9B9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Plu-iOS/Application/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1335,7 +1339,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Z225784MRD;
+				DEVELOPMENT_TEAM = AXN37CP9B9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Plu-iOS/Application/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
@@ -16,7 +16,7 @@ final class NicknameEditViewController: UIViewController {
     private let navigationBar = PLUNavigationBarView()
         .setTitle(text: "프로필 수정")
         .setLeftButton(type: .back)
-        .setRightButton(type: .logo)
+        .setRightButton(type: .text("완료"))
     
     private let textFieldSubject = PassthroughSubject<String, Never>()
     private var cancelBag = Set<AnyCancellable>()
@@ -33,7 +33,6 @@ final class NicknameEditViewController: UIViewController {
         setUI()
         setHierarchy()
         setLayout()
-        setAddTarget()
         bindInput()
         bind()
         setKeyboard()
@@ -56,7 +55,7 @@ private extension NicknameEditViewController {
             .sink { [weak self] in
                 guard let isActice = $0.nextProcessButtonIsActive, let description = $0.errorDescription else { return }
                 self?.errorLabel.text = description
-                self?.tempButton.setButtonState(isActice: isActice)
+                self?.navigationBar.setRightButtonState(isEnabled: isActice)
             }
             .store(in: &cancelBag)
         
@@ -114,10 +113,6 @@ private extension NicknameEditViewController {
     
     func setKeyboard() {
         self.nickNameTextField.becomeFirstResponder()
-    }
-    
-    func setAddTarget() {
-        self.tempButton.addTarget(self, action: #selector(tempButtonTapped), for: .touchUpInside)
     }
     
     func bindInput() {

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
@@ -13,13 +13,17 @@ import SnapKit
 
 final class NicknameEditViewController: UIViewController {
     
+    private let navigationBar = PLUNavigationBarView()
+        .setTitle(text: "프로필 수정")
+        .setLeftButton(type: .back)
+        .setRightButton(type: .logo)
+    
     private let textFieldSubject = PassthroughSubject<String, Never>()
     private var cancelBag = Set<AnyCancellable>()
     
     private let defaultProfileImage = PLUImageView(ImageLiterals.MyPage.profile92)
     private let nickNameTextField = PLUTextField()
     private let errorLabel = PLULabel(type: .body3, color: .error)
-    private let tempButton = PluTempButton(isActive: false)
     private let nicknameLabel = PLULabel(type: .body3, color: .gray600, text: "닉네임")
     
     private let viewModel = NicknameEditViewModel(nickNameManager: NicknameManagerStub())
@@ -55,6 +59,18 @@ private extension NicknameEditViewController {
                 self?.tempButton.setButtonState(isActice: isActice)
             }
             .store(in: &cancelBag)
+        
+        navigationBar.leftButtonTapSubject
+            .sink { _ in
+                print("왼쪽 버튼 tap")
+            }
+            .store(in: &cancelBag)
+        
+        navigationBar.rightButtonTapSubject
+            .sink { _ in
+                print("오른쪽 버튼")
+            }
+            .store(in: &cancelBag)
     }
 }
 
@@ -64,19 +80,17 @@ private extension NicknameEditViewController {
     }
     
     func setHierarchy() {
-        view.addSubviews(nicknameLabel, defaultProfileImage, nickNameTextField, errorLabel)
-        view.addSubview(tempButton)
+        view.addSubviews(nicknameLabel, defaultProfileImage, nickNameTextField, errorLabel, navigationBar)
     }
     
     func setLayout() {
-        tempButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(80)
-            make.trailing.equalToSuperview().inset(20)
-            make.size.equalTo(30)
+        navigationBar.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalToSuperview()
         }
         
         defaultProfileImage.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(36)
+            make.top.equalTo(navigationBar.snp.bottom).offset(36)
             make.centerX.equalToSuperview()
             make.size.equalTo(92)
         }
@@ -104,10 +118,6 @@ private extension NicknameEditViewController {
     
     func setAddTarget() {
         self.tempButton.addTarget(self, action: #selector(tempButtonTapped), for: .touchUpInside)
-    }
-    
-    @objc func tempButtonTapped() {
-        print("버튼이 눌렸습니다")
     }
     
     func bindInput() {

--- a/Plu-iOS/Plu-iOS/Scenes/PLUNavigationBarView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PLUNavigationBarView.swift
@@ -1,0 +1,130 @@
+//
+//  PLUNavigationBarView.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 12/14/23.
+//
+
+import UIKit
+import Combine
+
+final class PLUNavigationBarView: UIView {
+    // MARK: - Public Subjects
+    let leftButtonTapSubject = PassthroughSubject<Void, Never>()
+    let rightButtonTapSubject = PassthroughSubject<Void, Never>()
+    
+    enum LeftButtonType {
+        case logo
+        case back
+        
+        var image: UIImage {
+            switch self {
+            case .back: return ImageLiterals.NavigationBar.arrowLeft
+            case .logo: return ImageLiterals.NavigationBar.profile32
+            }
+        }
+    }
+    
+    enum RightButtonType {
+        case logo
+        case text(String)
+        
+        var image: UIImage? {
+            switch self {
+            case .logo: return ImageLiterals.NavigationBar.profile32
+            default: return nil
+            }
+        }
+    }
+    
+    private let leftButton = PLUButton(config: .plain())
+    
+    private let titleLabel = PLULabel(type: .head3, color: .gray800)
+    
+    private let rightButton = PLUButton(config: .plain())
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        setHierarchy()
+        setLayout()
+        bindInput()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func bindInput() {
+        leftButton.tapPublisher
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.leftButtonTapSubject.send(())
+            }
+            .store(in: &cancelBag)
+        
+        rightButton.tapPublisher
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.rightButtonTapSubject.send(())
+            }
+            .store(in: &cancelBag)
+    }
+    
+    @discardableResult
+    func setTitle(text: String) -> Self {
+        self.titleLabel.text = text
+        return self
+    }
+    
+    @discardableResult
+    func setLeftButton(type: LeftButtonType) -> Self {
+        leftButton.setImage(image: type.image, placement: .all)
+        return self
+    }
+    
+    @discardableResult
+    func setRightButton(type: RightButtonType) -> Self {
+        rightButton.isHidden = false
+        switch type {
+        case .logo:
+            rightButton.setImage(image: type.image!, placement: .all)
+        case .text(let text):
+            rightButton.setText(text: text, font: .subHead1)
+            rightButton.setBackForegroundColor(backgroundColor: .background, foregroundColor: .gray200)
+        }
+        return self
+    }
+}
+
+extension PLUNavigationBarView {
+    private func configureUI() {
+        rightButton.isHidden = true
+    }
+    
+    private func setHierarchy() {
+        self.addSubviews(leftButton, titleLabel, rightButton)
+    }
+    
+    private func setLayout() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(52)
+        }
+        
+        leftButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(20)
+            make.centerY.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        rightButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(20)
+            make.centerY.equalTo(titleLabel)
+        }
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/PLUNavigationBarView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PLUNavigationBarView.swift
@@ -97,6 +97,10 @@ final class PLUNavigationBarView: UIView {
         }
         return self
     }
+    
+    func setRightButtonState(isEnabled: Bool) {
+        rightButton.isEnabled = isEnabled
+    }
 }
 
 extension PLUNavigationBarView {


### PR DESCRIPTION
## 🌱 작업한 내용
- PLUNavigationBar를 구현했습니다.

## 🌱 PR Point
### OCP 고려
기존 라이온하트때는 아래와 같은 enum타입들을 모두 정의해서 필요한 UI와 세팅을 미리 모두 세팅해놓아 사용하는데에는 편리함이 있었습니다.
```swift
enum LHNavigationType {
    case today
    case explore
    case curriculumMain
    case curriculumByWeek
    ...
}

enum LeftBarItemType {
    case buttonWithRightBarItems
    case backButtonWithTitle
    case closeButtonWithTitle
}
```

하지만 PLU는 이제 정말 MVP단계이기에 Enum을 통해서 미리 타입을 지정해두면 유연해지지 않겠다라는 판단이 들어 이번에는 라이온하트와 다르게 타입을 미리 정해두지않고 기본 UI구현을 제공하지 않는 방향으로 구현하였습니다.

# 사용방법
## NavigationBar 선언
```swift
private let navigationBar = PLUNavigationBarView()
        .setTitle(text: "프로필 수정")
        .setLeftButton(type: .back)
        .setRightButton(type: .text("완료"))
```
위와 같이 `PLUButton`과 유사한 형태로 작성할 수 있습니다.

NavigationBar의 버튼들의 경우 크게 변경되지 않을 것이라 판단하여 Enum을 통해 세세한 것까지 인자를 받지 않도록 했습니다.

`setLeftButton`의 인자로 들어가는 `type`의 경우는 아래와 같습니다.
```swift
enum LeftButtonType {
        case logo
        case back
}
```
`setRightButton`의 인자로 들어가는 `type`의 경우는 아래와 같습니다.
```swift
enum RightButtonType {
        case logo
        case text(String)
}
```



## 버튼 액션받기
```swift
// MARK: - Public Subjects
let leftButtonTapSubject = PassthroughSubject<Void, Never>()
let rightButtonTapSubject = PassthroughSubject<Void, Never>()
```
위와 같은 public subject가 `NavigationBar`내에 존재합니다. 따라서 아래와 같이 해당 `subject`를 sink해서 사용하시면 됩니다.

```swift
navigationBar.leftButtonTapSubject
    .sink { _ in
        print("왼쪽 버튼 tap")
    }
    .store(in: &cancelBag)

navigationBar.rightButtonTapSubject
    .sink { _ in
        print("오른쪽 버튼")
    }
    .store(in: &cancelBag)
```



## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 프로필 변경 예시 | <img width="456" alt="스크린샷 2023-12-06 오후 4 38 00" src="https://github.com/Team-Plu/Plu-iOS/assets/60292150/5df3a42f-96cd-4505-8a24-d558433f8760"> |





## 📮 관련 이슈

- Resolved: #40 
