### PR TITLE
[FEAT] NicknameEditViewController MVVM-C(Combine) + Adaptor Pattern 적용(#65)

### DIFF
--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -141,12 +141,19 @@
 		C0A256272B1EE1200059AA7E /* MyPageAppVersionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A256262B1EE1200059AA7E /* MyPageAppVersionTableViewCell.swift */; };
 		C0CEF3DE2B267A4B00682D1B /* NicknameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CEF3DD2B267A4B00682D1B /* NicknameState.swift */; };
 		C0CEF3E02B267B3600682D1B /* NicknameCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CEF3DF2B267B3600682D1B /* NicknameCheck.swift */; };
+		C0CFE1D12B33CEA3001FB7A5 /* NicknameEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1D02B33CEA3001FB7A5 /* NicknameEditViewModel.swift */; };
+		C0CFE1D32B33CF43001FB7A5 /* NicknameEditNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1D22B33CF43001FB7A5 /* NicknameEditNavigation.swift */; };
+		C0CFE1D52B33CF89001FB7A5 /* NicknameEditAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1D42B33CF89001FB7A5 /* NicknameEditAdaptor.swift */; };
+		C0CFE1D92B33D2B0001FB7A5 /* OnboardingInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1D82B33D2B0001FB7A5 /* OnboardingInput.swift */; };
+		C0CFE1DB2B33D2BA001FB7A5 /* OnboardingOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1DA2B33D2BA001FB7A5 /* OnboardingOutput.swift */; };
+		C0CFE1DE2B33D2F4001FB7A5 /* NicknameEditInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1DD2B33D2F4001FB7A5 /* NicknameEditInput.swift */; };
+		C0CFE1E02B33D2FB001FB7A5 /* NicknameEditOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1DF2B33D2FB001FB7A5 /* NicknameEditOutput.swift */; };
 		C0D813EF2B312D1400F1B180 /* OnboardingViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D813EE2B312D1400F1B180 /* OnboardingViewModelImpl.swift */; };
 		C0D813F22B312E4200F1B180 /* OnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D813F12B312E4200F1B180 /* OnboardingNavigation.swift */; };
 		C0D813F42B312E7D00F1B180 /* OnboardingAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D813F32B312E7D00F1B180 /* OnboardingAdaptor.swift */; };
 		C0DBFB362B300EFF002F71A4 /* ExitUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DBFB352B300EFF002F71A4 /* ExitUser.swift */; };
 		C0E0D4F72B26C7FC00840C0B /* NicknameEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E0D4F62B26C7FC00840C0B /* NicknameEditViewController.swift */; };
-		C0E0D4F92B26C81700840C0B /* NicknameEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E0D4F82B26C81700840C0B /* NicknameEditViewModel.swift */; };
+		C0E0D4F92B26C81700840C0B /* NicknameEditViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E0D4F82B26C81700840C0B /* NicknameEditViewModelImpl.swift */; };
 		C0E0D4FB2B26CC4C00840C0B /* PLUImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E0D4FA2B26CC4C00840C0B /* PLUImageView.swift */; };
 		C0E93B402B2035370098A822 /* MyPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E93B3F2B2035370098A822 /* MyPageCell.swift */; };
 		C0E93B432B2035580098A822 /* MyPageUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E93B422B2035580098A822 /* MyPageUserData.swift */; };
@@ -315,12 +322,19 @@
 		C0A256262B1EE1200059AA7E /* MyPageAppVersionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAppVersionTableViewCell.swift; sourceTree = "<group>"; };
 		C0CEF3DD2B267A4B00682D1B /* NicknameState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameState.swift; sourceTree = "<group>"; };
 		C0CEF3DF2B267B3600682D1B /* NicknameCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameCheck.swift; sourceTree = "<group>"; };
+		C0CFE1D02B33CEA3001FB7A5 /* NicknameEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditViewModel.swift; sourceTree = "<group>"; };
+		C0CFE1D22B33CF43001FB7A5 /* NicknameEditNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditNavigation.swift; sourceTree = "<group>"; };
+		C0CFE1D42B33CF89001FB7A5 /* NicknameEditAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditAdaptor.swift; sourceTree = "<group>"; };
+		C0CFE1D82B33D2B0001FB7A5 /* OnboardingInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInput.swift; sourceTree = "<group>"; };
+		C0CFE1DA2B33D2BA001FB7A5 /* OnboardingOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOutput.swift; sourceTree = "<group>"; };
+		C0CFE1DD2B33D2F4001FB7A5 /* NicknameEditInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditInput.swift; sourceTree = "<group>"; };
+		C0CFE1DF2B33D2FB001FB7A5 /* NicknameEditOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditOutput.swift; sourceTree = "<group>"; };
 		C0D813EE2B312D1400F1B180 /* OnboardingViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModelImpl.swift; sourceTree = "<group>"; };
 		C0D813F12B312E4200F1B180 /* OnboardingNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNavigation.swift; sourceTree = "<group>"; };
 		C0D813F32B312E7D00F1B180 /* OnboardingAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAdaptor.swift; sourceTree = "<group>"; };
 		C0DBFB352B300EFF002F71A4 /* ExitUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitUser.swift; sourceTree = "<group>"; };
 		C0E0D4F62B26C7FC00840C0B /* NicknameEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditViewController.swift; sourceTree = "<group>"; };
-		C0E0D4F82B26C81700840C0B /* NicknameEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditViewModel.swift; sourceTree = "<group>"; };
+		C0E0D4F82B26C81700840C0B /* NicknameEditViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditViewModelImpl.swift; sourceTree = "<group>"; };
 		C0E0D4FA2B26CC4C00840C0B /* PLUImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLUImageView.swift; sourceTree = "<group>"; };
 		C0E93B3F2B2035370098A822 /* MyPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCell.swift; sourceTree = "<group>"; };
 		C0E93B422B2035580098A822 /* MyPageUserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageUserData.swift; sourceTree = "<group>"; };
@@ -963,8 +977,45 @@
 			isa = PBXGroup;
 			children = (
 				C0CEF3DD2B267A4B00682D1B /* NicknameState.swift */,
+				C0CFE1D82B33D2B0001FB7A5 /* OnboardingInput.swift */,
+				C0CFE1DA2B33D2BA001FB7A5 /* OnboardingOutput.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		C0CFE1D62B33D283001FB7A5 /* Adaptor */ = {
+			isa = PBXGroup;
+			children = (
+				C0CFE1D22B33CF43001FB7A5 /* NicknameEditNavigation.swift */,
+				C0CFE1D42B33CF89001FB7A5 /* NicknameEditAdaptor.swift */,
+			);
+			path = Adaptor;
+			sourceTree = "<group>";
+		};
+		C0CFE1D72B33D28C001FB7A5 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				C0E0D4F82B26C81700840C0B /* NicknameEditViewModelImpl.swift */,
+				C0CFE1D02B33CEA3001FB7A5 /* NicknameEditViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C0CFE1DC2B33D2E4001FB7A5 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C0CFE1DD2B33D2F4001FB7A5 /* NicknameEditInput.swift */,
+				C0CFE1DF2B33D2FB001FB7A5 /* NicknameEditOutput.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		C0CFE1E12B33D31E001FB7A5 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				C0E0D4F62B26C7FC00840C0B /* NicknameEditViewController.swift */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 		C0D813F02B312E3300F1B180 /* Adaptor */ = {
@@ -979,8 +1030,10 @@
 		C0E0D4F52B26C7C500840C0B /* NicknameEdit */ = {
 			isa = PBXGroup;
 			children = (
-				C0E0D4F62B26C7FC00840C0B /* NicknameEditViewController.swift */,
-				C0E0D4F82B26C81700840C0B /* NicknameEditViewModel.swift */,
+				C0CFE1E12B33D31E001FB7A5 /* ViewController */,
+				C0CFE1DC2B33D2E4001FB7A5 /* Model */,
+				C0CFE1D72B33D28C001FB7A5 /* ViewModel */,
+				C0CFE1D62B33D283001FB7A5 /* Adaptor */,
 			);
 			path = NicknameEdit;
 			sourceTree = "<group>";
@@ -1199,7 +1252,7 @@
 				C0E0D4FB2B26CC4C00840C0B /* PLUImageView.swift in Sources */,
 				B5ACF71C2B2815CB006D7641 /* AnswerDetailCoordinator.swift in Sources */,
 				C05E262F2B1C48F200D91BFA /* Font.swift in Sources */,
-				C0E0D4F92B26C81700840C0B /* NicknameEditViewModel.swift in Sources */,
+				C0E0D4F92B26C81700840C0B /* NicknameEditViewModelImpl.swift in Sources */,
 				B5ACF6D62B2078B2006D7641 /* AnswerFilterMenuView.swift in Sources */,
 				C05E26672B1D9B0500D91BFA /* UIView+.swift in Sources */,
 				B59FC6E72B1C44C9000996CA /* ImageLiterals.swift in Sources */,
@@ -1216,6 +1269,7 @@
 				4AA747702B261221004D0335 /* PLUEverydayAnswerView.swift in Sources */,
 				B5ACF7272B281928006D7641 /* SplashCoordinatorImpl.swift in Sources */,
 				4AA747612B24B495004D0335 /* AnswerCautionView.swift in Sources */,
+				C0CFE1D12B33CEA3001FB7A5 /* NicknameEditViewModel.swift in Sources */,
 				C0E93B522B2046030098A822 /* MyPageSectionHeaderHeight.swift in Sources */,
 				B5ACF7142B28133E006D7641 /* AuthCoordinator.swift in Sources */,
 				C0E93B452B2035650098A822 /* MyPageAlarmData.swift in Sources */,
@@ -1228,6 +1282,7 @@
 				C05E266D2B1D9B7200D91BFA /* UITextField+.swift in Sources */,
 				C0D813F42B312E7D00F1B180 /* OnboardingAdaptor.swift in Sources */,
 				B5ACF7042B26C807006D7641 /* RecordDiffableDataSource.swift in Sources */,
+				C0CFE1D52B33CF89001FB7A5 /* NicknameEditAdaptor.swift in Sources */,
 				C04E4CF42B2A8DCF00ABDFAA /* SelectMonthPopUpViewModelImpl.swift in Sources */,
 				C0E93B4B2B20359B0098A822 /* MyPageUserExitType.swift in Sources */,
 				C05E26902B1D9ED300D91BFA /* TabbarViewController.swift in Sources */,
@@ -1263,12 +1318,14 @@
 				B5ACF7102B27F193006D7641 /* Coordinator.swift in Sources */,
 				C0E93B432B2035580098A822 /* MyPageUserData.swift in Sources */,
 				B5ACF7122B2812E2006D7641 /* SplashCoordinator.swift in Sources */,
+				C0CFE1DE2B33D2F4001FB7A5 /* NicknameEditInput.swift in Sources */,
 				C0E93B402B2035370098A822 /* MyPageCell.swift in Sources */,
 				B5ACF71A2B28158E006D7641 /* OtherAnswersCoordinator.swift in Sources */,
 				B5ACF7252B2818D5006D7641 /* AppCoordinatorImpl.swift in Sources */,
 				4A4466712B2D8DB1002D5BF7 /* UserDefaultKey.swift in Sources */,
 				B5B744E42B32C87500AF368A /* Login.swift in Sources */,
 				C0E93B4E2B2036E50098A822 /* MyPageSection.swift in Sources */,
+				C0CFE1D32B33CF43001FB7A5 /* NicknameEditNavigation.swift in Sources */,
 				C0E0D4F72B26C7FC00840C0B /* NicknameEditViewController.swift in Sources */,
 				C05E265D2B1D9A5900D91BFA /* CollectionSectionViewRegisterDequeueProtocol.swift in Sources */,
 				C083F62A2B27EE4400808AE6 /* AlarmPopUpViewController.swift in Sources */,
@@ -1320,6 +1377,7 @@
 				B5ACF6CF2B1EECD0006D7641 /* OthersAnswerTableView.swift in Sources */,
 				C0682A822B25857200AD4DB4 /* PLUTextField.swift in Sources */,
 				B5B744CE2B312C5D00AF368A /* LoginViewModel.swift in Sources */,
+				C0CFE1E02B33D2FB001FB7A5 /* NicknameEditOutput.swift in Sources */,
 				C0D813F22B312E4200F1B180 /* OnboardingNavigation.swift in Sources */,
 				C05E269A2B1D9F1B00D91BFA /* SplashViewController.swift in Sources */,
 				C07AB7272B2828A600C2E02C /* TabbarCoordinator.swift in Sources */,
@@ -1328,7 +1386,9 @@
 				C04E4CF62B2AAE0B00ABDFAA /* PLUPopUpContainerView.swift in Sources */,
 				C0D813EF2B312D1400F1B180 /* OnboardingViewModelImpl.swift in Sources */,
 				C02C5DFE2B22E0780011F07C /* UIEdgeInsets+.swift in Sources */,
+				C0CFE1DB2B33D2BA001FB7A5 /* OnboardingOutput.swift in Sources */,
 				C0DBFB362B300EFF002F71A4 /* ExitUser.swift in Sources */,
+				C0CFE1D92B33D2B0001FB7A5 /* OnboardingInput.swift in Sources */,
 				4A44666A2B281F52002D5BF7 /* TodayQuestionCoordinatorImpl.swift in Sources */,
 				B5ACF70C2B26EC48006D7641 /* se+.swift in Sources */,
 				B5ACF7392B2A8ADC006D7641 /* PLUNavigationBarView.swift in Sources */,

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		C0CFE1DB2B33D2BA001FB7A5 /* OnboardingOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1DA2B33D2BA001FB7A5 /* OnboardingOutput.swift */; };
 		C0CFE1DE2B33D2F4001FB7A5 /* NicknameEditInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1DD2B33D2F4001FB7A5 /* NicknameEditInput.swift */; };
 		C0CFE1E02B33D2FB001FB7A5 /* NicknameEditOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1DF2B33D2FB001FB7A5 /* NicknameEditOutput.swift */; };
+		C0CFE1E32B3529AF001FB7A5 /* Publisher+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CFE1E22B3529AF001FB7A5 /* Publisher+.swift */; };
 		C0D813EF2B312D1400F1B180 /* OnboardingViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D813EE2B312D1400F1B180 /* OnboardingViewModelImpl.swift */; };
 		C0D813F22B312E4200F1B180 /* OnboardingNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D813F12B312E4200F1B180 /* OnboardingNavigation.swift */; };
 		C0D813F42B312E7D00F1B180 /* OnboardingAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D813F32B312E7D00F1B180 /* OnboardingAdaptor.swift */; };
@@ -329,6 +330,7 @@
 		C0CFE1DA2B33D2BA001FB7A5 /* OnboardingOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOutput.swift; sourceTree = "<group>"; };
 		C0CFE1DD2B33D2F4001FB7A5 /* NicknameEditInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditInput.swift; sourceTree = "<group>"; };
 		C0CFE1DF2B33D2FB001FB7A5 /* NicknameEditOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditOutput.swift; sourceTree = "<group>"; };
+		C0CFE1E22B3529AF001FB7A5 /* Publisher+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+.swift"; sourceTree = "<group>"; };
 		C0D813EE2B312D1400F1B180 /* OnboardingViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModelImpl.swift; sourceTree = "<group>"; };
 		C0D813F12B312E4200F1B180 /* OnboardingNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNavigation.swift; sourceTree = "<group>"; };
 		C0D813F32B312E7D00F1B180 /* OnboardingAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAdaptor.swift; sourceTree = "<group>"; };
@@ -708,6 +710,7 @@
 				C02C5DFD2B22E0780011F07C /* UIEdgeInsets+.swift */,
 				B5ACF70B2B26EC48006D7641 /* se+.swift */,
 				C07CD88E2B2BD4C80091DAAF /* UIButton+.swift */,
+				C0CFE1E22B3529AF001FB7A5 /* Publisher+.swift */,
 			);
 			path = Extention;
 			sourceTree = "<group>";
@@ -1319,6 +1322,7 @@
 				C0E93B432B2035580098A822 /* MyPageUserData.swift in Sources */,
 				B5ACF7122B2812E2006D7641 /* SplashCoordinator.swift in Sources */,
 				C0CFE1DE2B33D2F4001FB7A5 /* NicknameEditInput.swift in Sources */,
+				C0CFE1E32B3529AF001FB7A5 /* Publisher+.swift in Sources */,
 				C0E93B402B2035370098A822 /* MyPageCell.swift in Sources */,
 				B5ACF71A2B28158E006D7641 /* OtherAnswersCoordinator.swift in Sources */,
 				B5ACF7252B2818D5006D7641 /* AppCoordinatorImpl.swift in Sources */,

--- a/Plu-iOS/Plu-iOS/Application/AppDelegate.swift
+++ b/Plu-iOS/Plu-iOS/Application/AppDelegate.swift
@@ -33,4 +33,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
 }
-

--- a/Plu-iOS/Plu-iOS/Global/Constant/StringConstant.swift
+++ b/Plu-iOS/Plu-iOS/Global/Constant/StringConstant.swift
@@ -16,7 +16,7 @@ enum StringConstant {
     }
     
     enum MyPage {
-        case alarm, faq, openSource, privacy, appVersion, logOut, resign
+        case alarm, faq, openSource, privacy, appVersion, logOut, resign, nickName
         
         var description: String {
             switch self {
@@ -27,6 +27,7 @@ enum StringConstant {
             case .resign: return "탈퇴하기"
             case .openSource: return "오픈소스 라이브러리"
             case .privacy: return "개인정보 보호 및 약관"
+            case .nickName: return "닉네임"
             }
         }
     }

--- a/Plu-iOS/Plu-iOS/Global/Extention/Publisher+.swift
+++ b/Plu-iOS/Plu-iOS/Global/Extention/Publisher+.swift
@@ -1,0 +1,36 @@
+//
+//  Publisher+.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/22.
+//
+
+import Foundation
+import Combine
+
+extension Publisher {
+    func requestAPI<Output>(failure: Output,
+                            handler: @escaping (Self.Output) async throws -> (Output),
+                            errorHandler: @escaping ((NetworkError) -> ())) -> AnyPublisher<Output, Never> where Self.Failure == Never {
+        
+        return self.flatMap { input -> AnyPublisher<Output, Never> in
+                return Future<Output, NetworkError> { promise in
+                    Task {
+                        do {
+                            let output = try await handler(input)
+                            promise(.success(output))
+                        } catch {
+                            let networkError = error as! NetworkError
+                            errorHandler(networkError)
+                            promise(.failure(networkError))
+                        }
+                    }
+                }
+                .catch { _ in
+                    Just(failure)
+                }
+                .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Coordinator/CoordinatorImpl/MyPageCoordinatorImpl.swift
@@ -31,8 +31,9 @@ final class MyPageCoordinatorImpl: MyPageCoordinator {
     }
     
     func showProfileEditViewController() {
+        let adaptor = NicknameEditAdaptor(coordinator: self)
         let manager = NicknameManagerStub()
-        let viewModel = NicknameEditViewModelImpl(nickNameManager: manager, coordinator: self)
+        let viewModel = NicknameEditViewModelImpl(nickNameManager: manager, adaptor: adaptor)
         let profileEditViewController = NicknameEditViewController(viewModel: viewModel)
         self.navigationController?.pushViewController(profileEditViewController, animated: true)
     }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Adaptor/LoginAdaptor.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Adaptor/LoginAdaptor.swift
@@ -19,7 +19,8 @@ final class LoginAdaptor: LoginNavigation {
     func loginButtonTapped(type: LoginState) {
         switch type {
         case .loginSuccess:
-            self.coordinator.showTabbarController()
+            self.coordinator.showOnboardingController()
+//            self.coordinator.showTabbarController()
         case .userNotFound:
             self.coordinator.showOnboardingController()
         }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Adaptor/LoginAdaptor.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Adaptor/LoginAdaptor.swift
@@ -19,8 +19,7 @@ final class LoginAdaptor: LoginNavigation {
     func loginButtonTapped(type: LoginState) {
         switch type {
         case .loginSuccess:
-            self.coordinator.showOnboardingController()
-//            self.coordinator.showTabbarController()
+            self.coordinator.showTabbarController()
         case .userNotFound:
             self.coordinator.showOnboardingController()
         }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/ViewModel/LoginViewModel.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/ViewModel/LoginViewModel.swift
@@ -2,7 +2,7 @@
 //  LoginViewModel.swift
 //  Plu-iOS
 //
-//  Created by 김민재 on 12/19/23.
+//  Created by 김의성 on 12/19/23.
 //
 
 import Foundation

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Adaptor/NicknameEditAdaptor.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Adaptor/NicknameEditAdaptor.swift
@@ -1,0 +1,25 @@
+//
+//  NicknameEditAdaptor.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/21.
+//
+
+import Foundation
+
+final class NicknameEditAdaptor: NicknameEditNavigation {
+
+    let coordinator: MyPageCoordinator
+    
+    init(coordinator: MyPageCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+    func backButtonTapped() {
+        self.coordinator.pop()
+    }
+    
+    func nicknameChangeCompleteButtonTapped() {
+        self.coordinator.pop()
+    }
+}

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Adaptor/NicknameEditNavigation.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Adaptor/NicknameEditNavigation.swift
@@ -1,0 +1,13 @@
+//
+//  NicknameEditNavigation.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/21.
+//
+
+import Foundation
+
+protocol NicknameEditNavigation {
+    func backButtonTapped()
+    func nicknameChangeCompleteButtonTapped()
+}

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Model/NicknameEditInput.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Model/NicknameEditInput.swift
@@ -1,0 +1,15 @@
+//
+//  NicknameEditInput.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/21.
+//
+
+import Foundation
+import Combine
+
+struct NicknameEditInput {
+    let textFieldSubject: AnyPublisher<String, Never>
+    let naviagtionLeftButtonTapped: PassthroughSubject<Void, Never>
+    let naviagtionRightButtonTapped: PassthroughSubject<String?, Never>
+}

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Model/NicknameEditOutput.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/Model/NicknameEditOutput.swift
@@ -1,0 +1,14 @@
+//
+//  NicknameEditOutput.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/21.
+//
+
+import Foundation
+import Combine
+
+struct NicknameEditOutput {
+    let nickNameResultPublisher: AnyPublisher<NicknameState, Never>
+    let loadingViewSubject: AnyPublisher<LoadingState, Never>
+}

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
@@ -14,9 +14,9 @@ import SnapKit
 final class NicknameEditViewController: UIViewController {
     
     private let navigationBar = PLUNavigationBarView()
-        .setTitle(text: "프로필 수정")
+        .setTitle(text: StringConstant.Navibar.title.profileEdit)
         .setLeftButton(type: .back)
-        .setRightButton(type: .text("완료"))
+        .setRightButton(type: .text(StringConstant.Navibar.title.completeRightButton))
     
     private let navigationLeftButtonTapped = PassthroughSubject<Void, Never>()
     private let navigationRightButtonTapped = PassthroughSubject<String?, Never>()
@@ -25,7 +25,7 @@ final class NicknameEditViewController: UIViewController {
     private let defaultProfileImage = PLUImageView(ImageLiterals.MyPage.profile92)
     private let nickNameTextField = PLUTextField()
     private let errorLabel = PLULabel(type: .body3, color: .error)
-    private let nicknameLabel = PLULabel(type: .body3, color: .gray600, text: "닉네임")
+    private let nicknameLabel = PLULabel(type: .body3, color: .gray600, text: StringConstant.MyPage.nickName.description)
     
     private lazy var activityIndicator = PLUIndicator(parent: self)
     private let viewModel: NicknameEditViewModel

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/NicknameEditViewController.swift
@@ -27,7 +27,6 @@ final class NicknameEditViewController: UIViewController {
     private let errorLabel = PLULabel(type: .body3, color: .error)
     private let nicknameLabel = PLULabel(type: .body3, color: .gray600, text: StringConstant.MyPage.nickName.description)
     
-    private lazy var activityIndicator = PLUIndicator(parent: self)
     private let viewModel: NicknameEditViewModel
     
     init(viewModel: NicknameEditViewModel) {
@@ -84,7 +83,7 @@ private extension NicknameEditViewController {
         output.loadingViewSubject
             .receive(on: DispatchQueue.main)
             .sink { _ in
-                self.activityIndicator.stopAnimating()
+                self.navigationBar.setActivityIndicator(isShow: false, isImage: false)
             }
             .store(in: &cancelBag)
         
@@ -96,7 +95,7 @@ private extension NicknameEditViewController {
         
         navigationBar.rightButtonTapSubject
             .sink { [weak self] in
-                self?.activityIndicator.startAnimating()
+                self?.navigationBar.setActivityIndicator(isShow: true, isImage: false)
                 self?.navigationRightButtonTapped.send(self?.nickNameTextField.text)
             }
             .store(in: &cancelBag)
@@ -112,7 +111,6 @@ private extension NicknameEditViewController {
     
     func setHierarchy() {
         view.addSubviews(nicknameLabel, defaultProfileImage, nickNameTextField, errorLabel, navigationBar)
-        view.addSubview(activityIndicator)
     }
     
     func setLayout() {

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewController/NicknameEditViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewController/NicknameEditViewController.swift
@@ -51,7 +51,7 @@ final class NicknameEditViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        setKeyboard()
+        self.nickNameTextField.becomeFirstResponder()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -144,9 +144,5 @@ private extension NicknameEditViewController {
             make.top.equalTo(nickNameTextField.snp.bottom).offset(12)
             make.leading.equalToSuperview().inset(20)
         }
-    }
-    
-    func setKeyboard() {
-        self.nickNameTextField.becomeFirstResponder()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewController/NicknameEditViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewController/NicknameEditViewController.swift
@@ -27,9 +27,9 @@ final class NicknameEditViewController: UIViewController {
     private let errorLabel = PLULabel(type: .body3, color: .error)
     private let nicknameLabel = PLULabel(type: .body3, color: .gray600, text: StringConstant.MyPage.nickName.description)
     
-    private let viewModel: NicknameEditViewModel
+    private let viewModel: any NicknameEditViewModel
     
-    init(viewModel: NicknameEditViewModel) {
+    init(viewModel: some NicknameEditViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -99,8 +99,6 @@ private extension NicknameEditViewController {
                 self?.navigationRightButtonTapped.send(self?.nickNameTextField.text)
             }
             .store(in: &cancelBag)
-        
-        
     }
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewController/NicknameEditViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewController/NicknameEditViewController.swift
@@ -43,6 +43,7 @@ final class NicknameEditViewController: UIViewController {
         setUI()
         setHierarchy()
         setLayout()
+        bindInput()
         bind()
         /// 임시로 넣어놨습니다
         nickNameTextField.setTextfieldDefaultInput(input: "의성")
@@ -68,8 +69,26 @@ final class NicknameEditViewController: UIViewController {
 }
 
 private extension NicknameEditViewController {
+    func bindInput() {
+        navigationBar.leftButtonTapSubject
+            .sink { [weak self] in
+                self?.navigationLeftButtonTapped.send(())
+            }
+            .store(in: &cancelBag)
+        
+        navigationBar.rightButtonTapSubject
+            .sink { [weak self] in
+                self?.navigationBar.setActivityIndicator(isShow: true, isImage: false)
+                self?.navigationRightButtonTapped.send(self?.nickNameTextField.text)
+            }
+            .store(in: &cancelBag)
+    }
+    
     func bind() {
-        let input = NicknameEditInput(textFieldSubject: self.nickNameTextField.textPublisher, naviagtionLeftButtonTapped: navigationLeftButtonTapped, naviagtionRightButtonTapped: navigationRightButtonTapped)
+        let input = NicknameEditInput(textFieldSubject: self.nickNameTextField.textPublisher,
+                                      naviagtionLeftButtonTapped: navigationLeftButtonTapped,
+                                      naviagtionRightButtonTapped: navigationRightButtonTapped)
+        
         let output = self.viewModel.transform(input: input)
         output.nickNameResultPublisher
             .receive(on: DispatchQueue.main)
@@ -84,19 +103,6 @@ private extension NicknameEditViewController {
             .receive(on: DispatchQueue.main)
             .sink { _ in
                 self.navigationBar.setActivityIndicator(isShow: false, isImage: false)
-            }
-            .store(in: &cancelBag)
-        
-        navigationBar.leftButtonTapSubject
-            .sink { [weak self] in
-                self?.navigationLeftButtonTapped.send(())
-            }
-            .store(in: &cancelBag)
-        
-        navigationBar.rightButtonTapSubject
-            .sink { [weak self] in
-                self?.navigationBar.setActivityIndicator(isShow: true, isImage: false)
-                self?.navigationRightButtonTapped.send(self?.nickNameTextField.text)
             }
             .store(in: &cancelBag)
     }

--- a/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewModel/NicknameEditViewModel.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/NicknameEdit/ViewModel/NicknameEditViewModel.swift
@@ -1,0 +1,10 @@
+//
+//  NicknameViewModel.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/21.
+//
+
+import Foundation
+
+protocol NicknameEditViewModel: ViewModel where Input == NicknameEditInput, Output == NicknameEditOutput {}

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingInput.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingInput.swift
@@ -1,0 +1,15 @@
+//
+//  OnboardingInput.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/21.
+//
+
+import Foundation
+import Combine
+
+struct OnboardingInput {
+    let textFieldSubject: AnyPublisher<String, Never>
+    let backButtonTapped: PassthroughSubject<Void, Never>
+    let singInButtonTapped: PassthroughSubject<String, Never>
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingOutput.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingOutput.swift
@@ -10,5 +10,5 @@ import Combine
 
 struct OnboardingOutput {
     let nickNameResultPublisher: AnyPublisher<NicknameState, Never>
-    let signInStatePublisher: AnyPublisher<LoadingState, Never>
+    let signInStatePublisher: AnyPublisher<AppData<String?>, Never>
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingOutput.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingOutput.swift
@@ -10,5 +10,5 @@ import Combine
 
 struct OnboardingOutput {
     let nickNameResultPublisher: AnyPublisher<NicknameState, Never>
-    let signInStatePublisher: AnyPublisher<AppData<String?>, Never>
+    let signInStatePublisher: AnyPublisher<LoadingState, Never>
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingOutput.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/Model/OnboardingOutput.swift
@@ -1,0 +1,14 @@
+//
+//  OnboardingOutput.swift
+//  Plu-iOS
+//
+//  Created by uiskim on 2023/12/21.
+//
+
+import Foundation
+import Combine
+
+struct OnboardingOutput {
+    let nickNameResultPublisher: AnyPublisher<NicknameState, Never>
+    let signInStatePublisher: AnyPublisher<LoadingState, Never>
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/OnboardingInteface/NicknameCheck.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/OnboardingInteface/NicknameCheck.swift
@@ -22,13 +22,13 @@ protocol NicknameCheck {
                                    to checker: textFieldVaildChecker) -> textFieldOutput
     func getNicknameVaildPublisher(from checker: textFieldVaildChecker,
                                    with manager: NicknameManager) -> textFieldOutput
-    func makeNicknameResultPublisher(from input: textFieldInput,
+    func nicknamePublisher(from input: textFieldInput,
                                      to checker: textFieldVaildChecker,
                                      with manager: NicknameManager) -> textFieldOutput
 }
 
 extension NicknameCheck where Self: AnyObject {
-    func makeNicknameResultPublisher(from input: textFieldInput, to checker: textFieldVaildChecker, with manager: NicknameManager) -> textFieldOutput {
+    func nicknamePublisher(from input: textFieldInput, to checker: textFieldVaildChecker, with manager: NicknameManager) -> textFieldOutput {
         let stateFromNicknamePublisher = self.getNicknameStatePublisher(from: input, to: checker)
         let nickNameValidPublisher = self.getNicknameVaildPublisher(from: checker, with: manager)
         return stateFromNicknamePublisher.merge(with: nickNameValidPublisher).eraseToAnyPublisher()

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewController/OnboardingViewController.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewController/OnboardingViewController.swift
@@ -38,9 +38,6 @@ final class OnboardingViewController: UIViewController {
         .setText(text: StringConstant.Onboarding.buttonTitle.description!, font: .title1)
         .setLayer(cornerRadius: 8)
     
-    // 추후에 button내부의 indicator로 변경 예정
-    private lazy var loadingView = PLUIndicator(parent: self)
-    
     private let viewModel: any OnboardingViewModel
     
     init(viewModel: some OnboardingViewModel) {
@@ -93,7 +90,7 @@ private extension OnboardingViewController {
         output.signInStatePublisher
             .receive(on: DispatchQueue.main)
             .sink { _ in
-                self.loadingView.stopAnimating()
+                self.signInButton.setActivityIndicator(isShow: false, isImage: false)
             }
             .store(in: &cancelBag)
     }
@@ -108,7 +105,7 @@ private extension OnboardingViewController {
         self.signInButton.tapPublisher
             .sink { [weak self] in
                 guard let text = self?.nickNameTextField.text else { return }
-                self?.loadingView.startAnimating()
+                self?.signInButton.setActivityIndicator(isShow: true, isImage: false)
                 self?.singInButtonTapped.send(text)
                 self?.signInButton.isUserInteractionEnabled = false
             }
@@ -125,7 +122,6 @@ private extension OnboardingViewController {
     
     func setHierarchy() {
         view.addSubviews(navigationBar, titleLabel, subTitleLabel, nickNameTextField, errorLabel, signInButton)
-        view.addSubview(loadingView)
     }
     
     func setLayout() {

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -6,19 +6,6 @@
 //
 
 import Foundation
-import Combine
 
-struct OnboardingInput {
-    let textFieldSubject: AnyPublisher<String, Never>
-    let backButtonTapped: PassthroughSubject<Void, Never>
-    let singInButtonTapped: PassthroughSubject<String, Never>
-}
-
-struct OnboardingOutput {
-    let nickNameResultPublisher: AnyPublisher<NicknameState, Never>
-    let signInStatePublisher: AnyPublisher<LoadingState, Never>
-}
-
-protocol OnboardingViewModel: ViewModel where Input == OnboardingInput, Output == OnboardingOutput {
-}
+protocol OnboardingViewModel: ViewModel where Input == OnboardingInput, Output == OnboardingOutput {}
 

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewModel/OnboardingViewModelImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewModel/OnboardingViewModelImpl.swift
@@ -8,17 +8,6 @@
 import Foundation
 import Combine
 
-struct AppData {
-    let state: LoadingState
-    let data: String?
-}
-
-extension AppData {
-    static var testErrorCase: Self {
-        return .init(state: .error(message: "에러발생"), data: nil)
-    }
-}
-
 // 모든 비동기 코드는 optional의 데이터와 state가 무조건 들어가잖아
 // 얘를 프로토콜로 빼고
 
@@ -40,51 +29,22 @@ final class OnboardingViewModelImpl: OnboardingViewModel, NicknameCheck {
             .sink { [weak self] _ in self?.adaptor.backButtonTapped() }
             .store(in: &cancelBag)
         
-        let nicknameInput = input.textFieldSubject
-        let checker = self.vaildNicknameSubject
-        let nickNameResultPublisher = self.makeNicknameResultPublisher(from: nicknameInput, to: checker, with: nickNameManager)
+        let nickNameResultPublisher = self.nicknamePublisher(from: input.textFieldSubject, to: self.vaildNicknameSubject, with: nickNameManager)
         
 
-        // 문제 1 타입추론이 안되서 타입 명시를 해줘야한다
-        let signInStatePublisher: AnyPublisher<AppData, Never> = input.singInButtonTapped
-            .makeFuture(failure: .testErrorCase) { nickname in
+        let signInStatePublisher: AnyPublisher<LoadingState, Never> = input.singInButtonTapped
+            .requestAPI(failure: .error(message: "오류가발생했습니다")) { nickname in
                 try await Task.sleep(nanoseconds: 100_000_000_0)
                 try await self.nickNameManager.registerUser(nickName: nickname)
                 self.adaptor.signInButtonTapped()
-                return .init(state: .end, data: nil)
+                return .end
             } errorHandler: { error in
                 // 에러처리하는 코드
             }
-
-        
-
     
         
         return OnboardingOutput(nickNameResultPublisher: nickNameResultPublisher, signInStatePublisher: signInStatePublisher)
     }
 }
 
-extension Publisher {
-    func makeFuture<Output>(failure: Output, handler: @escaping (Self.Output) async throws -> (Output), errorHandler: @escaping ((NetworkError) -> ())) -> AnyPublisher<Output, Never> where Self.Failure == Never {
-        return self
-            .flatMap { input -> AnyPublisher<Output, Never> in
-                return Future<Output, NetworkError> { promise in
-                    Task {
-                        do {
-                            promise(.success(try await handler(input)))
-                        } catch {
-                            let networkError = error as! NetworkError
-                            errorHandler(networkError)
-                            promise(.failure(networkError))
-                        }
-                    }
-                }
-                .catch { _ in
-                    Just(failure)
-                }
-                .eraseToAnyPublisher()
-            }
-            .eraseToAnyPublisher()
-    }
-}
 

--- a/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewModel/OnboardingViewModelImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Onboarding/ViewModel/OnboardingViewModelImpl.swift
@@ -8,6 +8,20 @@
 import Foundation
 import Combine
 
+struct AppData {
+    let state: LoadingState
+    let data: String?
+}
+
+extension AppData {
+    static var testErrorCase: Self {
+        return .init(state: .error(message: "에러발생"), data: nil)
+    }
+}
+
+// 모든 비동기 코드는 optional의 데이터와 state가 무조건 들어가잖아
+// 얘를 프로토콜로 빼고
+
 final class OnboardingViewModelImpl: OnboardingViewModel, NicknameCheck {
 
     var nickNameManager: NicknameManager
@@ -30,29 +44,47 @@ final class OnboardingViewModelImpl: OnboardingViewModel, NicknameCheck {
         let checker = self.vaildNicknameSubject
         let nickNameResultPublisher = self.makeNicknameResultPublisher(from: nicknameInput, to: checker, with: nickNameManager)
         
-        let signInStatePublisher = input.singInButtonTapped
-            .flatMap { nickname -> AnyPublisher<LoadingState, Never> in
-                return Future<LoadingState, Error> { promise in
+
+        // 문제 1 타입추론이 안되서 타입 명시를 해줘야한다
+        let signInStatePublisher: AnyPublisher<AppData, Never> = input.singInButtonTapped
+            .makeFuture(failure: .testErrorCase) { nickname in
+                try await Task.sleep(nanoseconds: 100_000_000_0)
+                try await self.nickNameManager.registerUser(nickName: nickname)
+                self.adaptor.signInButtonTapped()
+                return .init(state: .end, data: nil)
+            } errorHandler: { error in
+                // 에러처리하는 코드
+            }
+
+        
+
+    
+        
+        return OnboardingOutput(nickNameResultPublisher: nickNameResultPublisher, signInStatePublisher: signInStatePublisher)
+    }
+}
+
+extension Publisher {
+    func makeFuture<Output>(failure: Output, handler: @escaping (Self.Output) async throws -> (Output), errorHandler: @escaping ((NetworkError) -> ())) -> AnyPublisher<Output, Never> where Self.Failure == Never {
+        return self
+            .flatMap { input -> AnyPublisher<Output, Never> in
+                return Future<Output, NetworkError> { promise in
                     Task {
                         do {
-                            try await Task.sleep(nanoseconds: 100_000_000_0)
-                            try await self.nickNameManager.registerUser(nickName: nickname)
-                            self.adaptor.signInButtonTapped()
-                            promise(.success(.end))
+                            promise(.success(try await handler(input)))
                         } catch {
-                            promise(.failure(error))
+                            let networkError = error as! NetworkError
+                            errorHandler(networkError)
+                            promise(.failure(networkError))
                         }
                     }
                 }
                 .catch { _ in
-                    Just(.error(message: "유저 등록 오류 발생"))
+                    Just(failure)
                 }
                 .eraseToAnyPublisher()
             }
             .eraseToAnyPublisher()
-    
-        
-        return OnboardingOutput(nickNameResultPublisher: nickNameResultPublisher, signInStatePublisher: signInStatePublisher)
     }
 }
 

--- a/Plu-iOS/Plu-iOS/Scenes/PLUNavigationBarView.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/PLUNavigationBarView.swift
@@ -113,6 +113,10 @@ final class PLUNavigationBarView: UIView {
         config?.baseForegroundColor = .designSystem(isEnabled ? .gray600 : .gray200)
         rightButton.configuration = config
     }
+    
+    func setActivityIndicator(isShow: Bool, isImage: Bool) {
+        self.rightButton.setActivityIndicator(isShow: isShow, isImage: isImage)
+    }
 }
 
 extension PLUNavigationBarView {


### PR DESCRIPTION
## [#65] FEAT : NicknameEditViewController MVVM-C(Combine) + Adaptor Pattern 적용

## 🌱 작업한 내용
- ‼️기존 비동기로 api를 호출할떄 Future을 호출하는 방식을 메서드로 분리했습니다‼️
- 닉네임수정관련 뷰들을 MVVM으로 리팩터링 진행헀습니다
- 버튼을 loadingview에서 button내부의 loadingview로 변경했습니다

## 🌱 PR Point
## Future을 호출하는 방식을 메서드로 분리
### 1. Future를 사용하는 기존방식
- combine을 사용하지만 swift concurrency를 사용하고 싶어 future를 사용해 async/await을 활용하는 방식을 사용했습니다
- 코드가 반복되는 부분이 너무 많아서 관찰을 해보니 `api통신에 대한 로직`, `성공했을때 보내주는 Output`, `실패했을떄 보내주는 Output`만 메서드의 인풋으로 받으면 아래에 flatmap을 사용하고 Future를 마늘어서 catch를 하고 eraseToAnyPublisher를 하는 반복되는 로직을 사용하지 않아도 되지 않을까라는 생각이 들었습니다
> 기존코드의 보일러플레이트를 줄일수있을것이라 생각됩니다

### 2. Future를 사용하는 새로운 방식
```swift
extension Publisher {
    func requestAPI<Output>(failure: Output,
                            handler: @escaping (Self.Output) async throws -> (Output),
                            errorHandler: @escaping ((NetworkError) -> ())) -> AnyPublisher<Output, Never> where Self.Failure == Never {
        
        return self.flatMap { input -> AnyPublisher<Output, Never> in
                return Future<Output, NetworkError> { promise in
                    Task {
                        do {
                            let output = try await handler(input)
                            promise(.success(output))
                        } catch {
                            let networkError = error as! NetworkError
                            errorHandler(networkError)
                            promise(.failure(networkError))
                        }
                    }
                }
                .catch { _ in
                    Just(failure)
                }
                .eraseToAnyPublisher()
            }
            .eraseToAnyPublisher()
    }
}
```
- requestAPI라는 메서드를 만들어서 failure를 인자로 받는데 `성공했을떄 보내주는 Output`은 인자로 받는대신 네트워크통신의 결과를 사용해야할수도있어 메서드를 실행할떄 인자로 받으면 시점에 대한 문제가 발생할 수 있다고 생각했습니다, 그래서 클로저 자체의 output을 명시해줘서 handler의 클로저가 return되면 해당 return value가 성공시 promise로 들어가게끔 설계했습니다

- 하지만 해당 방식의 주의해야할 점이 있는데 메서드의 generic자체를 parameter로 meta type으로 받지 않으면 컴파일타임에서 generic을 특정할 수가 없는 문제가 있습니다 그렇다고 meta type을 받기에는 애매한 부분이 있어서 publisher의 변수를 선언할때 타입을 명시해줘야합니다
```swift
let signInStatePublisher: `AnyPublisher<LoadingState, Never>` = input.singInButtonTapped
    .requestAPI(failure: .error(message: "오류가발생했습니다")) { nickname in
        try await Task.sleep(nanoseconds: 100_000_000_0)
        try await self.nickNameManager.registerUser(nickName: nickname)
        self.adaptor.signInButtonTapped()
        return .end
    } errorHandler: { error in
        // 에러처리하는 코드
    }
```
- `let signInStatePublisher: `AnyPublisher<LoadingState, Never>` = ...` 처럼 publisher 변수 선언시 타입을 명시해줘야 generic의 타입이 구체화 될 수 있으니 이부분만 주의해주시면 됩니다
---


- 이전 pr에서처럼 `@MainActor`을 사용하기에 viewmodel내부에서 navigation관련 subject를 제거했습니다
- MVVM리팩터링 관련해서는 이전 pr에서 설명을 했기에 따로 확인할 부분은 없습니다
- https://github.com/Team-Plu/Plu-iOS/pull/61

## 📮 관련 이슈
- Resolved: #65
