### PR TITLE
[FEAT] 소셜로그인 추가 (#82)

### DIFF
--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -115,6 +115,18 @@
 		B5B7451C2B35252400AF368A /* ResignManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B7451B2B35252400AF368A /* ResignManager.swift */; };
 		B5B7451E2B35255100AF368A /* ResignManagerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B7451D2B35255100AF368A /* ResignManagerImpl.swift */; };
 		B5CD675B2B7F0C0F00EE48A1 /* AppleLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */; };
+		B5F1DD382B7F1E7200A2A5BA /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD372B7F1E7200A2A5BA /* KakaoSDK */; };
+		B5F1DD3A2B7F1E7200A2A5BA /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD392B7F1E7200A2A5BA /* KakaoSDKAuth */; };
+		B5F1DD3C2B7F1E7200A2A5BA /* KakaoSDKCert in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD3B2B7F1E7200A2A5BA /* KakaoSDKCert */; };
+		B5F1DD3E2B7F1E7200A2A5BA /* KakaoSDKCertCore in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD3D2B7F1E7200A2A5BA /* KakaoSDKCertCore */; };
+		B5F1DD402B7F1E7200A2A5BA /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD3F2B7F1E7200A2A5BA /* KakaoSDKCommon */; };
+		B5F1DD422B7F1E7200A2A5BA /* KakaoSDKFriend in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD412B7F1E7200A2A5BA /* KakaoSDKFriend */; };
+		B5F1DD442B7F1E7200A2A5BA /* KakaoSDKFriendCore in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD432B7F1E7200A2A5BA /* KakaoSDKFriendCore */; };
+		B5F1DD462B7F1E7200A2A5BA /* KakaoSDKNavi in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD452B7F1E7200A2A5BA /* KakaoSDKNavi */; };
+		B5F1DD482B7F1E7200A2A5BA /* KakaoSDKShare in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD472B7F1E7200A2A5BA /* KakaoSDKShare */; };
+		B5F1DD4A2B7F1E7200A2A5BA /* KakaoSDKTalk in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD492B7F1E7200A2A5BA /* KakaoSDKTalk */; };
+		B5F1DD4C2B7F1E7200A2A5BA /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD4B2B7F1E7200A2A5BA /* KakaoSDKTemplate */; };
+		B5F1DD4E2B7F1E7200A2A5BA /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD4D2B7F1E7200A2A5BA /* KakaoSDKUser */; };
 		C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113D92B25359100B2C799 /* OnboardingViewModel.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
 		C0121A2E2B1347CA00D10EB0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2D2B1347CA00D10EB0 /* SceneDelegate.swift */; };
@@ -463,9 +475,21 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5F1DD402B7F1E7200A2A5BA /* KakaoSDKCommon in Frameworks */,
 				C05E26452B1D971800D91BFA /* Kingfisher in Frameworks */,
+				B5F1DD422B7F1E7200A2A5BA /* KakaoSDKFriend in Frameworks */,
+				B5F1DD382B7F1E7200A2A5BA /* KakaoSDK in Frameworks */,
+				B5F1DD462B7F1E7200A2A5BA /* KakaoSDKNavi in Frameworks */,
+				B5F1DD482B7F1E7200A2A5BA /* KakaoSDKShare in Frameworks */,
 				C05E26422B1D970C00D91BFA /* SnapKit in Frameworks */,
+				B5F1DD4A2B7F1E7200A2A5BA /* KakaoSDKTalk in Frameworks */,
+				B5F1DD4E2B7F1E7200A2A5BA /* KakaoSDKUser in Frameworks */,
+				B5F1DD3C2B7F1E7200A2A5BA /* KakaoSDKCert in Frameworks */,
+				B5F1DD4C2B7F1E7200A2A5BA /* KakaoSDKTemplate in Frameworks */,
 				C0771C7E2B705FCD00780707 /* Carbon in Frameworks */,
+				B5F1DD3A2B7F1E7200A2A5BA /* KakaoSDKAuth in Frameworks */,
+				B5F1DD442B7F1E7200A2A5BA /* KakaoSDKFriendCore in Frameworks */,
+				B5F1DD3E2B7F1E7200A2A5BA /* KakaoSDKCertCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1472,6 +1496,18 @@
 				C05E26412B1D970C00D91BFA /* SnapKit */,
 				C05E26442B1D971800D91BFA /* Kingfisher */,
 				C0771C7D2B705FCD00780707 /* Carbon */,
+				B5F1DD372B7F1E7200A2A5BA /* KakaoSDK */,
+				B5F1DD392B7F1E7200A2A5BA /* KakaoSDKAuth */,
+				B5F1DD3B2B7F1E7200A2A5BA /* KakaoSDKCert */,
+				B5F1DD3D2B7F1E7200A2A5BA /* KakaoSDKCertCore */,
+				B5F1DD3F2B7F1E7200A2A5BA /* KakaoSDKCommon */,
+				B5F1DD412B7F1E7200A2A5BA /* KakaoSDKFriend */,
+				B5F1DD432B7F1E7200A2A5BA /* KakaoSDKFriendCore */,
+				B5F1DD452B7F1E7200A2A5BA /* KakaoSDKNavi */,
+				B5F1DD472B7F1E7200A2A5BA /* KakaoSDKShare */,
+				B5F1DD492B7F1E7200A2A5BA /* KakaoSDKTalk */,
+				B5F1DD4B2B7F1E7200A2A5BA /* KakaoSDKTemplate */,
+				B5F1DD4D2B7F1E7200A2A5BA /* KakaoSDKUser */,
 			);
 			productName = "Plu-iOS";
 			productReference = C0121A282B1347CA00D10EB0 /* Plu-iOS.app */;
@@ -1549,6 +1585,7 @@
 				C05E26402B1D970C00D91BFA /* XCRemoteSwiftPackageReference "SnapKit" */,
 				C05E26432B1D971800D91BFA /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				C0771C7C2B705FCD00780707 /* XCRemoteSwiftPackageReference "Carbon" */,
+				B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			productRefGroup = C0121A292B1347CA00D10EB0 /* Products */;
 			projectDirPath = "";
@@ -2146,6 +2183,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.20.0;
+			};
+		};
 		C05E26402B1D970C00D91BFA /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -2173,6 +2218,66 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		B5F1DD372B7F1E7200A2A5BA /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
+		B5F1DD392B7F1E7200A2A5BA /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		B5F1DD3B2B7F1E7200A2A5BA /* KakaoSDKCert */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCert;
+		};
+		B5F1DD3D2B7F1E7200A2A5BA /* KakaoSDKCertCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCertCore;
+		};
+		B5F1DD3F2B7F1E7200A2A5BA /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		B5F1DD412B7F1E7200A2A5BA /* KakaoSDKFriend */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKFriend;
+		};
+		B5F1DD432B7F1E7200A2A5BA /* KakaoSDKFriendCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKFriendCore;
+		};
+		B5F1DD452B7F1E7200A2A5BA /* KakaoSDKNavi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKNavi;
+		};
+		B5F1DD472B7F1E7200A2A5BA /* KakaoSDKShare */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKShare;
+		};
+		B5F1DD492B7F1E7200A2A5BA /* KakaoSDKTalk */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKTalk;
+		};
+		B5F1DD4B2B7F1E7200A2A5BA /* KakaoSDKTemplate */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKTemplate;
+		};
+		B5F1DD4D2B7F1E7200A2A5BA /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5F1DD362B7F1E7200A2A5BA /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
 		C05E26412B1D970C00D91BFA /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C05E26402B1D970C00D91BFA /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		B5B7451C2B35252400AF368A /* ResignManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B7451B2B35252400AF368A /* ResignManager.swift */; };
 		B5B7451E2B35255100AF368A /* ResignManagerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B7451D2B35255100AF368A /* ResignManagerImpl.swift */; };
 		B5CD675B2B7F0C0F00EE48A1 /* AppleLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */; };
+		B5F1DD352B7F1ABD00A2A5BA /* KakaoLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F1DD342B7F1ABD00A2A5BA /* KakaoLoginService.swift */; };
 		B5F1DD382B7F1E7200A2A5BA /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD372B7F1E7200A2A5BA /* KakaoSDK */; };
 		B5F1DD3A2B7F1E7200A2A5BA /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD392B7F1E7200A2A5BA /* KakaoSDKAuth */; };
 		B5F1DD3C2B7F1E7200A2A5BA /* KakaoSDKCert in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD3B2B7F1E7200A2A5BA /* KakaoSDKCert */; };
@@ -363,6 +364,7 @@
 		B5B7451B2B35252400AF368A /* ResignManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignManager.swift; sourceTree = "<group>"; };
 		B5B7451D2B35255100AF368A /* ResignManagerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignManagerImpl.swift; sourceTree = "<group>"; };
 		B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginService.swift; sourceTree = "<group>"; };
+		B5F1DD342B7F1ABD00A2A5BA /* KakaoLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginService.swift; sourceTree = "<group>"; };
 		B5F1DD4F2B7F202600A2A5BA /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 		B5F1DD512B7F215400A2A5BA /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		B5F1DD522B7F228900A2A5BA /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
@@ -879,6 +881,7 @@
 			isa = PBXGroup;
 			children = (
 				B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */,
+				B5F1DD342B7F1ABD00A2A5BA /* KakaoLoginService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1695,6 +1698,7 @@
 				C0D813F42B312E7D00F1B180 /* OnboardingAdaptor.swift in Sources */,
 				B5ACF7042B26C807006D7641 /* RecordDiffableDataSource.swift in Sources */,
 				C0CFE1D52B33CF89001FB7A5 /* NicknameEditAdaptor.swift in Sources */,
+				B5F1DD352B7F1ABD00A2A5BA /* KakaoLoginService.swift in Sources */,
 				C04E4CF42B2A8DCF00ABDFAA /* SelectMonthPopUpViewModelImpl.swift in Sources */,
 				C0E93B4B2B20359B0098A822 /* MyPageUserExitType.swift in Sources */,
 				C05E26902B1D9ED300D91BFA /* TabbarViewController.swift in Sources */,

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		B5F1DD4A2B7F1E7200A2A5BA /* KakaoSDKTalk in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD492B7F1E7200A2A5BA /* KakaoSDKTalk */; };
 		B5F1DD4C2B7F1E7200A2A5BA /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD4B2B7F1E7200A2A5BA /* KakaoSDKTemplate */; };
 		B5F1DD4E2B7F1E7200A2A5BA /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = B5F1DD4D2B7F1E7200A2A5BA /* KakaoSDKUser */; };
+		B5F1DD532B7F228900A2A5BA /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F1DD522B7F228900A2A5BA /* Config.swift */; };
 		C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113D92B25359100B2C799 /* OnboardingViewModel.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
 		C0121A2E2B1347CA00D10EB0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2D2B1347CA00D10EB0 /* SceneDelegate.swift */; };
@@ -362,6 +363,9 @@
 		B5B7451B2B35252400AF368A /* ResignManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignManager.swift; sourceTree = "<group>"; };
 		B5B7451D2B35255100AF368A /* ResignManagerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignManagerImpl.swift; sourceTree = "<group>"; };
 		B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginService.swift; sourceTree = "<group>"; };
+		B5F1DD4F2B7F202600A2A5BA /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
+		B5F1DD512B7F215400A2A5BA /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		B5F1DD522B7F228900A2A5BA /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		C00113D92B25359100B2C799 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C0121A282B1347CA00D10EB0 /* Plu-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Plu-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -879,6 +883,15 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		B5F1DD502B7F214600A2A5BA /* Configurations */ = {
+			isa = PBXGroup;
+			children = (
+				B5F1DD4F2B7F202600A2A5BA /* Development.xcconfig */,
+				B5F1DD512B7F215400A2A5BA /* Release.xcconfig */,
+			);
+			path = Configurations;
+			sourceTree = "<group>";
+		};
 		C0121A1F2B1347CA00D10EB0 = {
 			isa = PBXGroup;
 			children = (
@@ -935,10 +948,12 @@
 		C05E26462B1D976700D91BFA /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				B5F1DD502B7F214600A2A5BA /* Configurations */,
 				C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */,
 				C0121A2D2B1347CA00D10EB0 /* SceneDelegate.swift */,
 				C0121A362B1347CB00D10EB0 /* LaunchScreen.storyboard */,
 				C0121A392B1347CB00D10EB0 /* Info.plist */,
+				B5F1DD522B7F228900A2A5BA /* Config.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1695,6 +1710,7 @@
 				C0A256252B1EE0330059AA7E /* MyPageGeneralTableViewCell.swift in Sources */,
 				4AA7476E2B26119D004D0335 /* AnswerDetailViewController.swift in Sources */,
 				C05E26702B1D9B8C00D91BFA /* UIStackView+.swift in Sources */,
+				B5F1DD532B7F228900A2A5BA /* Config.swift in Sources */,
 				4AA7475D2B22E28F004D0335 /* PLUUnderLine.swift in Sources */,
 				C05E26942B1D9EF700D91BFA /* TodayQuestionViewController.swift in Sources */,
 				B5ACF7182B281530006D7641 /* MyAnswerCoordinator.swift in Sources */,
@@ -1883,6 +1899,7 @@
 /* Begin XCBuildConfiguration section */
 		C0121A502B1347CB00D10EB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD4F2B7F202600A2A5BA /* Development.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1943,6 +1960,7 @@
 		};
 		C0121A512B1347CB00D10EB0 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD512B7F215400A2A5BA /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1997,6 +2015,7 @@
 		};
 		C0121A532B1347CB00D10EB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD4F2B7F202600A2A5BA /* Development.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2032,6 +2051,7 @@
 		};
 		C0121A542B1347CB00D10EB0 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD512B7F215400A2A5BA /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2067,6 +2087,7 @@
 		};
 		C0121A562B1347CB00D10EB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD4F2B7F202600A2A5BA /* Development.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -2087,6 +2108,7 @@
 		};
 		C0121A572B1347CB00D10EB0 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD512B7F215400A2A5BA /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -2107,6 +2129,7 @@
 		};
 		C0121A592B1347CB00D10EB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD4F2B7F202600A2A5BA /* Development.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -2125,6 +2148,7 @@
 		};
 		C0121A5A2B1347CB00D10EB0 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5F1DD512B7F215400A2A5BA /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		B5B745192B3524F100AF368A /* ResignViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B745182B3524F100AF368A /* ResignViewModelImpl.swift */; };
 		B5B7451C2B35252400AF368A /* ResignManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B7451B2B35252400AF368A /* ResignManager.swift */; };
 		B5B7451E2B35255100AF368A /* ResignManagerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B7451D2B35255100AF368A /* ResignManagerImpl.swift */; };
+		B5CD675B2B7F0C0F00EE48A1 /* AppleLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */; };
 		C00113DA2B25359100B2C799 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00113D92B25359100B2C799 /* OnboardingViewModel.swift */; };
 		C0121A2C2B1347CA00D10EB0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */; };
 		C0121A2E2B1347CA00D10EB0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0121A2D2B1347CA00D10EB0 /* SceneDelegate.swift */; };
@@ -348,6 +349,7 @@
 		B5B745182B3524F100AF368A /* ResignViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignViewModelImpl.swift; sourceTree = "<group>"; };
 		B5B7451B2B35252400AF368A /* ResignManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignManager.swift; sourceTree = "<group>"; };
 		B5B7451D2B35255100AF368A /* ResignManagerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignManagerImpl.swift; sourceTree = "<group>"; };
+		B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginService.swift; sourceTree = "<group>"; };
 		C00113D92B25359100B2C799 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C0121A282B1347CA00D10EB0 /* Plu-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Plu-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0121A2B2B1347CA00D10EB0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -845,6 +847,14 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		B5CD67592B7F0BFA00EE48A1 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				B5CD675A2B7F0C0F00EE48A1 /* AppleLoginService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		C0121A1F2B1347CA00D10EB0 = {
 			isa = PBXGroup;
 			children = (
@@ -1090,6 +1100,7 @@
 		C05E267A2B1D9E1900D91BFA /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				B5CD67592B7F0BFA00EE48A1 /* Services */,
 				B5B744E02B31355E00AF368A /* Adaptor */,
 				B5B744DF2B31355700AF368A /* View */,
 				B5B744DE2B31355200AF368A /* ViewController */,
@@ -1664,6 +1675,7 @@
 				B5B7450A2B3491F400AF368A /* AnswerFilter.swift in Sources */,
 				C05E26982B1D9F1000D91BFA /* LoginViewController.swift in Sources */,
 				4A44666F2B2B2035002D5BF7 /* UserDefaultsManager.swift in Sources */,
+				B5CD675B2B7F0C0F00EE48A1 /* AppleLoginService.swift in Sources */,
 				C05E268E2B1D9EC800D91BFA /* OthersAnswerViewController.swift in Sources */,
 				B5ACF6F12B22D116006D7641 /* RecordQuestionTableViewCell.swift in Sources */,
 				B5ACF6CD2B1EE735006D7641 /* AnswerView.swift in Sources */,

--- a/Plu-iOS/Plu-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Plu-iOS/Plu-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "3dc6a42c7727c49bf26508e29b0a0b35f9c7e1ad",
+        "version" : "5.8.1"
+      }
+    },
+    {
       "identity" : "carbon",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ra1028/Carbon",
@@ -16,6 +25,15 @@
       "state" : {
         "revision" : "14c66681e12a38b81045f44c6c29724a0d4b0e72",
         "version" : "1.1.5"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "ae3c60cbd4e3b348775f8c766e5b908fa1e66c5a",
+        "version" : "2.20.0"
       }
     },
     {

--- a/Plu-iOS/Plu-iOS/Application/AppDelegate.swift
+++ b/Plu-iOS/Plu-iOS/Application/AppDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import KakaoSDKCommon
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -14,6 +16,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        let kakaoNativeAppKey = Config.kakaoNativeAppKey
+        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
         return true
     }
 

--- a/Plu-iOS/Plu-iOS/Application/Config.swift
+++ b/Plu-iOS/Plu-iOS/Application/Config.swift
@@ -1,0 +1,42 @@
+//
+//  Config.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 2/16/24.
+//
+
+import Foundation
+
+enum Config {
+
+    enum Keys {
+        enum Plist {
+            static let kakaoNativeAppKey = "KAKAO_NATIVE_APP_KEY"
+            static let baseURL = "BASE_URL"
+        }
+    }
+
+    private static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else {
+            fatalError("plist cannot found !!!")
+        }
+        return dict
+    }()
+}
+
+
+extension Config {
+    static let kakaoNativeAppKey: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.kakaoNativeAppKey] as? String else {
+            fatalError("KAKAO_NATIVE_APP_KEY is not set in plist for this configuration")
+        }
+        return key
+    }()
+
+    static let baseURL: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.baseURL] as? String else {
+            fatalError("BASE_URL is not set in plist for this configuration")
+        }
+        return key
+    }()
+}

--- a/Plu-iOS/Plu-iOS/Application/Configurations/Development.xcconfig
+++ b/Plu-iOS/Plu-iOS/Application/Configurations/Development.xcconfig
@@ -1,0 +1,12 @@
+//
+//  Development.xcconfig
+//  Plu-iOS
+//
+//  Created by 김민재 on 2/16/24.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+KAKAO_NATIVE_APP_KEY = bb98e0484e9fa39a5fbe9afea26de27b
+

--- a/Plu-iOS/Plu-iOS/Application/Configurations/Release.xcconfig
+++ b/Plu-iOS/Plu-iOS/Application/Configurations/Release.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Release.xcconfig
+//  Plu-iOS
+//
+//  Created by 김민재 on 2/16/24.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+KAKAO_NATIVE_APP_KEY = 4de113967a5e8542b25bfcd27a81a597

--- a/Plu-iOS/Plu-iOS/Application/Info.plist
+++ b/Plu-iOS/Plu-iOS/Application/Info.plist
@@ -2,6 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>$(KAKAO_NATIVE_APP_KEY)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao${KAKAO_NATIVE_APP_KEY}</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
+++ b/Plu-iOS/Plu-iOS/Application/SceneDelegate.swift
@@ -7,10 +7,20 @@
 
 import UIKit
 
+import KakaoSDKAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     var appCoordinator: AppCoordinatorImpl?
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
+    }
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }

--- a/Plu-iOS/Plu-iOS/Network/NetworkError.swift
+++ b/Plu-iOS/Plu-iOS/Network/NetworkError.swift
@@ -16,6 +16,7 @@ enum NetworkError: Error, Equatable {
     case unAuthorizedError
     case clientError(code: String, message: String)
     case serverError
+    case kakaoError
 }
 
 extension NetworkError: LocalizedError {
@@ -35,6 +36,8 @@ extension NetworkError: LocalizedError {
             return "📱클라이언트 에러 code: \(code), message:\(message)"
         case .serverError:
             return "🖥️서버 에러"
+        case .kakaoError:
+            return "Kakao 에러"
         }
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Manager/LoginManagerImpl.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Manager/LoginManagerImpl.swift
@@ -11,10 +11,11 @@ import Foundation
 final class LoginManagerImpl: LoginManager {
     func login(type: LoginType, token: String) async throws {
         print("\(type.rawValue): \(token)으로 로그인 시도")
+        //TODO: 자체 네트워크 Service로 로그인 API 호출
         if type == .kakao {
             return
         } else {
-            throw NetworkError.serverError
+            return
         }
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Model/Login.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Model/Login.swift
@@ -26,7 +26,6 @@ extension Login {
         return Future<(type: LoginType, state: LoadingState), NetworkError> { promise in
             Task {
                 do {
-                    try await Task.sleep(nanoseconds: 100_000_000_0)
                     let token = try await socialLogin.getToken()
                     try await manager.login(type: socialLogin.type, token: token)
                     navigator.loginButtonTapped(type: .loginSuccess)

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Model/SocialLogin.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Model/SocialLogin.swift
@@ -15,7 +15,7 @@ protocol SocialLogin {
     func getToken() async throws -> String
 }
 
-struct Kakao: SocialLogin {
+final class Kakao: SocialLogin {
     var type: LoginType = .kakao
     
     var errorMessage: String = "카카오 로그인 오류"
@@ -34,8 +34,10 @@ struct Kakao: SocialLogin {
     }
 }
 
-struct Apple: SocialLogin {
+final class Apple: SocialLogin {
     var type: LoginType = .apple
+    
+    private let appleService = AppleLoginService()
     
     var errorMessage: String = "애플 로그인 실패" 
     
@@ -45,6 +47,6 @@ struct Apple: SocialLogin {
     
     private func loginApple() async throws -> String {
         // Apple 로직
-        return "apple token"
+        return try await appleService.login()
     }
 }

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Model/SocialLogin.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Model/SocialLogin.swift
@@ -18,20 +18,18 @@ protocol SocialLogin {
 final class Kakao: SocialLogin {
     var type: LoginType = .kakao
     
+    private let kakaoService = KakaoLoginService()
+    
     var errorMessage: String = "카카오 로그인 오류"
     
     func getToken() async throws -> String {
-        return try await loginKakaoWithApp()
+        return try await loginKakao()
     }
     
-    private func loginKakaoWithApp() async throws -> String {
-        // login 로직
-        return "kakao app token"
+    private func loginKakao() async throws -> String {
+        return try await kakaoService.login()
     }
     
-    private func loginKakaoWithWeb() async throws -> String {
-        return "kakao web token"
-    }
 }
 
 final class Apple: SocialLogin {

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Services/AppleLoginService.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Services/AppleLoginService.swift
@@ -1,0 +1,49 @@
+//
+//  AppleLoginService.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 2/16/24.
+//
+
+import Foundation
+import AuthenticationServices
+
+
+final class AppleLoginService: NSObject {
+    
+    private var activeContinuation: CheckedContinuation<String, Error>?
+    
+    func login() async throws -> String {
+        let appleProvider = ASAuthorizationAppleIDProvider()
+        let request = appleProvider.createRequest()
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.performRequests()
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            self.activeContinuation = continuation
+        }
+    }
+    
+}
+
+extension AppleLoginService: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let identityToken = credential.identityToken
+        else { return }
+        
+        
+        self.activeContinuation?.resume(
+            returning: String(data: identityToken , encoding: .utf8) ?? ""
+        )
+        self.activeContinuation = nil
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        self.activeContinuation?.resume(throwing: error)
+        self.activeContinuation = nil
+    }
+    
+    
+}

--- a/Plu-iOS/Plu-iOS/Scenes/Login/Services/KakaoLoginService.swift
+++ b/Plu-iOS/Plu-iOS/Scenes/Login/Services/KakaoLoginService.swift
@@ -1,0 +1,57 @@
+//
+//  KakaoLoginService.swift
+//  Plu-iOS
+//
+//  Created by 김민재 on 2/16/24.
+//
+
+import Foundation
+
+import KakaoSDKAuth
+import KakaoSDKUser
+
+
+final class KakaoLoginService {
+    
+    func login() async throws -> String {
+        if UserApi.isKakaoTalkLoginAvailable() {
+            return try await loginKakaoWithApp()
+        }
+        return try await loginKakaoWithWeb()
+        
+    }
+    
+    @MainActor
+    private func loginKakaoWithApp() async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            UserApi.shared.loginWithKakaoTalk { oAuthToken, error in
+                guard error == nil else {
+                    continuation.resume(throwing: NetworkError.serverError)
+                    return
+                }
+                guard let oAuthToken = oAuthToken else {
+                    continuation.resume(throwing: NetworkError.serverError)
+                    return
+                }
+                continuation.resume(returning: oAuthToken.accessToken)
+            }
+        }
+    }
+    
+    @MainActor
+    private func loginKakaoWithWeb() async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            UserApi.shared.loginWithKakaoAccount { oAuthToken, error in
+                guard error == nil else {
+                    continuation.resume(throwing: NetworkError.serverError)
+                    return
+                }
+                guard let oAuthToken = oAuthToken else {
+                    continuation.resume(throwing: NetworkError.serverError)
+                    return
+                }
+                continuation.resume(returning: oAuthToken.accessToken)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 작업한 내용

- 카카오 로그인 추가
- 애플 로그인 추가

## 🌱 PR Point
Delegate을 통해 전달받는 값을 async-await interface로 변경해서 사용하였습니다.
```swift
final class AppleLoginService: NSObject {
    
    private var activeContinuation: CheckedContinuation<String, Error>?
    
    func login() async throws -> String {
        let appleProvider = ASAuthorizationAppleIDProvider()
        let request = appleProvider.createRequest()
        let controller = ASAuthorizationController(authorizationRequests: [request])
        controller.delegate = self
        controller.performRequests()
        
        return try await withCheckedThrowingContinuation { continuation in
            self.activeContinuation = continuation
        }
    }
    
}

extension AppleLoginService: ASAuthorizationControllerDelegate {
    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
              let identityToken = credential.identityToken
        else { return }
        
        
        self.activeContinuation?.resume(
            returning: String(data: identityToken , encoding: .utf8) ?? ""
        )
        self.activeContinuation = nil
    }
    
    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
        self.activeContinuation?.resume(throwing: error)
        self.activeContinuation = nil
    }
}
```


## 📮 관련 이슈

- Resolved: #82 
